### PR TITLE
Update kernel 2 (#5) In this merge, I try to build a baseline that ca…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,7 +405,8 @@ set(xml_headers "")
 set(header_dest "gen_headers/arch/api/invocation.h")
 gen_invocation_header(
     OUTPUT ${header_dest}
-    XML ${CMAKE_CURRENT_SOURCE_DIR}/libsel4/arch_include/${KernelArch}/interfaces/sel4arch.xml
+    XML
+        ${CMAKE_CURRENT_SOURCE_DIR}/libsel4/arch_include/${KernelArch}/interfaces/object-api-arch.xml
     ARCH
 )
 list(APPEND xml_headers "${header_dest}")
@@ -415,7 +416,7 @@ set(header_dest "gen_headers/arch/api/sel4_invocation.h")
 gen_invocation_header(
     OUTPUT "${header_dest}"
     XML
-        "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/sel4_arch_include/${KernelSel4Arch}/interfaces/sel4arch.xml"
+        "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/sel4_arch_include/${KernelSel4Arch}/interfaces/object-api-sel4-arch.xml"
     SEL4ARCH
 )
 list(APPEND xml_headers "${header_dest}")
@@ -424,7 +425,7 @@ list(APPEND gen_files_list "${header_dest}")
 set(header_dest "gen_headers/api/invocation.h")
 gen_invocation_header(
     OUTPUT "${header_dest}"
-    XML "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/include/interfaces/sel4.xml"
+    XML "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/include/interfaces/object-api.xml"
 )
 list(APPEND xml_headers "${header_dest}")
 list(APPEND gen_files_list "${header_dest}")
@@ -514,18 +515,14 @@ add_custom_command(
 add_custom_target(dummy_header_wrapper DEPENDS ${dummy_headers})
 
 cppfile(
-    kernel_all_pp_prune.c
-    kernel_all_pp_prune_wrapper
-    kernel_all.c
-    EXTRA_FLAGS
-    -CC
-    "-I${CMAKE_CURRENT_BINARY_DIR}/generated_prune"
+    kernel_all_pp_prune.c kernel_all_pp_prune_wrapper kernel_all.c
+	EXTRA_FLAGS -CC "-I${CMAKE_CURRENT_BINARY_DIR}/generated_prune"
     EXTRA_DEPS
     kernel_all_c_wrapper
-    dummy_header_wrapper
-    xml_headers_target
-    kernel_config_headers
-    ${gen_files_list}
+	dummy_header_wrapper
+	xml_headers_target
+	kernel_config_headers
+	${gen_files_list}
 )
 
 #
@@ -570,14 +567,9 @@ foreach(bf_dec ${bf_declarations})
     set(pbf_name "generated/${bf_gen_dir}/${bf_name}.pbf")
     set(pbf_target "${bf_gen_target}_pbf")
     cppfile(
-        "${pbf_name}"
-        "${pbf_target}"
-        "${bf_file}"
-        EXTRA_FLAGS
-        -P
-        EXTRA_DEPS
-        kernel_config_headers
-        ${gen_files_list}
+        "${pbf_name}" "${pbf_target}" "${bf_file}"
+        EXTRA_FLAGS -P
+        EXTRA_DEPS kernel_config_headers ${gen_files_list}
     )
     GenHBFTarget(
         ""
@@ -629,18 +621,12 @@ set(CPPExtraFlags "-I${CMAKE_CURRENT_BINARY_DIR}/generated")
 #
 
 cppfile(
-    kernel_all.i
-    kernel_i_wrapper
-    kernel_all.c
-    EXTRA_DEPS
-    kernel_all_c_wrapper
-    kernel_headers
-    ${gen_files_list}
+    kernel_all.i kernel_i_wrapper kernel_all.c
+    EXTRA_DEPS kernel_all_c_wrapper kernel_headers ${gen_files_list}
     EXTRA_FLAGS
-    -CC
-    "${CPPExtraFlags}"
-    # The circular_includes script relies upon parsing out exactly 'kernel_all_copy.c' as
-    # a special case so we must ask cppfile to use this input name
+    -CC "${CPPExtraFlags}"
+        # The circular_includes script relies upon parsing out exactly 'kernel_all_copy.c' as
+        # a special case so we must ask cppfile to use this input name
     EXACT_NAME kernel_all_copy.c
 )
 
@@ -658,16 +644,9 @@ set(linker_lds_path "${CMAKE_CURRENT_BINARY_DIR}/linker.lds_pp")
 
 # Preprocess the linker script
 cppfile(
-    "${linker_lds_path}"
-    linker_ld_wrapper
-    "${linker_source}"
-    EXTRA_DEPS
-    kernel_headers
-    ${gen_files_list}
-    EXTRA_FLAGS
-    -CC
-    -P
-    "${CPPExtraFlags}"
+    "${linker_lds_path}" linker_ld_wrapper "${linker_source}"
+    EXTRA_DEPS kernel_headers ${gen_files_list}
+    EXTRA_FLAGS -CC -P "${CPPExtraFlags}"
 )
 
 add_custom_command(
@@ -751,21 +730,8 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
         PATTERN "*.pbf"
         PATTERN "api/syscall.xml"
         PATTERN "api/syscall.xsd"
-        PATTERN "interfaces/sel4.xml"
+        PATTERN "object-api*.xml"
         PATTERN "gen_config.json"
-    )
-    # Manually resolve conflict between the two files name sel4arch.xml
-    install(
-        FILES
-            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/arch_include/${KernelArch}/interfaces/sel4arch.xml"
-        DESTINATION libsel4/include/interfaces
-        RENAME sel4-arch.xml
-    )
-    install(
-        FILES
-            "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/sel4_arch_include/${KernelSel4Arch}/interfaces/sel4arch.xml"
-        DESTINATION libsel4/include/interfaces
-        RENAME sel4-sel4arch.xml
     )
     # Install libsel4 sources to libsel4/src
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libsel4/src/" DESTINATION libsel4/src)
@@ -776,5 +742,8 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     if(DEFINED platform_yaml)
         install(FILES ${platform_yaml} DESTINATION support)
     endif()
+		if(DEFINED platform_json)
+		install(FILES ${platform_json} DESTINATION support)
+	endif()
 
 endif()

--- a/include/arch/arm/arch/64/mode/fastpath/fastpath.h
+++ b/include/arch/arm/arch/64/mode/fastpath/fastpath.h
@@ -25,7 +25,7 @@ compile_assert(SysReplyRecv_Minus2, SysReplyRecv == -2)
 
 /* Use macros to not break verification */
 #define endpoint_ptr_get_epQueue_tail_fp(ep_ptr) TCB_PTR(endpoint_ptr_get_epQueue_tail(ep_ptr))
-#define cap_vtable_cap_get_vspace_root_fp(vtable_cap) cap_vtable_root_get_basePtr(vtable_cap)
+#define cap_vtable_cap_get_vspace_root_fp(vtable_cap) VSPACE_PTR(cap_vspace_cap_get_capVSBasePtr(vtable_cap))
 
 static inline void FORCE_INLINE
 switchToThread_fp(tcb_t *thread, vspace_root_t *vroot, pde_t stored_hw_asid)
@@ -96,8 +96,8 @@ static inline void mdb_node_ptr_set_mdbPrev_np(mdb_node_t *node_ptr, word_t mdbP
 
 static inline bool_t isValidVTableRoot_fp(cap_t vspace_root_cap)
 {
-    return cap_capType_equals(vspace_root_cap, cap_vtable_root_cap)
-           && cap_vtable_root_isMapped(vspace_root_cap);
+    return cap_capType_equals(vspace_root_cap, cap_vspace_cap)
+           && cap_vspace_cap_get_capVSIsMapped(vspace_root_cap);
 }
 
 /* This is an accelerated check that msgLength, which appears

--- a/include/arch/arm/arch/64/mode/kernel/vspace.h
+++ b/include/arch/arm/arch/64/mode/kernel/vspace.h
@@ -18,11 +18,6 @@
 bool_t CONST isVTableRoot(cap_t cap);
 bool_t CONST isValidNativeRoot(cap_t cap);
 
-pgde_t *pageUpperDirectoryMapped(asid_t asid, vptr_t vaddr, pude_t *pud);
-pude_t *pageDirectoryMapped(asid_t asid, vptr_t vaddr, pde_t *pd);
-void unmapPageUpperDirectory(asid_t asid, vptr_t vaddr, pude_t *pud);
-void unmapPageDirectory(asid_t asid, vptr_t vaddr, pde_t *pd);
-
 void unmapPageTable(asid_t asid, vptr_t vaddr, pte_t *pt);
 void unmapPage(vm_page_size_t page_size, asid_t asid, vptr_t vptr, pptr_t pptr);
 
@@ -43,99 +38,29 @@ static const region_t BOOT_RODATA *mode_reserved_region = NULL;
 #define PAR_EL1_MASK 0x0000fffffffff000ul
 #define GET_PAR_ADDR(x) ((x) & PAR_EL1_MASK)
 
-#ifdef AARCH64_VSPACE_S2_START_L1
 
-#define cap_vtable_root_cap cap_page_upper_directory_cap
-#define cap_vtable_root_get_mappedASID(_c) \
-    cap_page_upper_directory_cap_get_capPUDMappedASID(_c)
-#define cap_vtable_root_get_basePtr(_c) \
-    VSPACE_PTR(cap_page_upper_directory_cap_get_capPUDBasePtr(_c))
-#define cap_vtable_root_isMapped(_c) \
-    cap_page_upper_directory_cap_get_capPUDIsMapped(_c)
-
-#ifdef CONFIG_ARM_SMMU
-#define cap_vtable_root_get_mappedCB(_c) \
-    cap_page_upper_directory_cap_get_capPUDMappedCB(_c)
-#define cap_vtable_root_ptr_set_mappedCB(_c, cb) \
-    cap_page_upper_directory_cap_ptr_set_capPUDMappedCB(_c, cb)
-#define cap_vtable_cap_new(_a, _v, _m) cap_page_upper_directory_cap_new(_a, _v, _m, 0, CB_INVALID)
-#else
-#define cap_vtable_cap_new(_a, _v, _m) cap_page_upper_directory_cap_new(_a, _v, _m, 0)
-#endif  /*!CONFIG_ARM_SMMU*/
-
-#define vtable_invalid_get_stored_asid_valid(_v) \
-    pude_pude_invalid_get_stored_asid_valid(_v)
-#define vtable_invalid_get_stored_hw_asid(_v) pude_pude_invalid_get_stored_hw_asid(_v)
 
 static inline exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *poolPtr, cte_t *cte)
 {
-    cap_page_upper_directory_cap_ptr_set_capPUDMappedASID(&cte->cap, asid);
-    cap_page_upper_directory_cap_ptr_set_capPUDIsMapped(&cte->cap, 1);
-    asid_map_t asid_map = asid_map_asid_map_vspace_new(
-#ifdef CONFIG_ARM_SMMU
-                              /* bind_cb: Number of bound context banks */
-                              0,
-#endif
-                              /* vspace_root: reference to vspace root page table object */
-                              cap_page_upper_directory_cap_get_capPUDBasePtr(cte->cap)
-#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-                              /* stored_hw_vmid, stored_vmid_valid: Assigned hardware VMID for TLB. */
-                              , 0, false
-#endif
-                          );
-    poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
-    return EXCEPTION_NONE;
-}
+	//TODO
+//     cap_t cap = vspaceCapSlot->cap;
+//     asid_map_t asid_map = asid_map_asid_map_vspace_new(
+// #ifdef CONFIG_ARM_SMMU
+//                               /* bind_cb: Number of bound context banks */
+//                               0,
+// #endif
+//                               /* vspace_root: reference to vspace root page table object */
+//                             //   cap_page_global_directory_cap_get_capPGDBasePtr(cte->cap)
+// #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+//                               /* stored_hw_vmid, stored_vmid_valid: Assigned hardware VMID for TLB. */
+//                               , 0, false
+// #endif
+//                           );
 
-
-#else
-
-#define cap_vtable_root_cap cap_page_global_directory_cap
-#define cap_vtable_root_get_mappedASID(_c) \
-    cap_page_global_directory_cap_get_capPGDMappedASID(_c)
-#define cap_vtable_root_get_basePtr(_c) \
-    PGDE_PTR(cap_page_global_directory_cap_get_capPGDBasePtr(_c))
-#define cap_vtable_root_isMapped(_c) cap_page_global_directory_cap_get_capPGDIsMapped(_c)
-
-#ifdef CONFIG_ARM_SMMU
-#define cap_vtable_root_get_mappedCB(_c) \
-    cap_page_global_directory_cap_get_capPGDMappedCB(_c)
-#define cap_vtable_root_ptr_set_mappedCB(_c, cb) \
-    cap_page_global_directory_cap_ptr_set_capPGDMappedCB(_c, cb)
-#define cap_vtable_cap_new(_a, _v, _m) \
-    cap_page_global_directory_cap_new(_a, _v, _m, CB_INVALID)
-#else
-#define cap_vtable_cap_new(_a, _v, _m) \
-    cap_page_global_directory_cap_new(_a, _v, _m)
-#endif /*!CONFIG_ARM_SMMU*/
-
-#define vtable_invalid_get_stored_asid_valid(_v) \
-    pgde_pgde_invalid_get_stored_asid_valid(_v)
-#define vtable_invalid_get_stored_hw_asid(_v) pgde_pgde_invalid_get_stored_hw_asid(_v)
-
-static inline exception_t performASIDPoolInvocation(asid_t asid, asid_pool_t *poolPtr, cte_t *cte)
-{
-    cap_page_global_directory_cap_ptr_set_capPGDMappedASID(&cte->cap, asid);
-    cap_page_global_directory_cap_ptr_set_capPGDIsMapped(&cte->cap, 1);
-    asid_map_t asid_map = asid_map_asid_map_vspace_new(
-#ifdef CONFIG_ARM_SMMU
-                              /* bind_cb: Number of bound context banks */
-                              0,
-#endif
-                              /* vspace_root: reference to vspace root page table object */
-                              cap_page_global_directory_cap_get_capPGDBasePtr(cte->cap)
-#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-                              /* stored_hw_vmid, stored_vmid_valid: Assigned hardware VMID for TLB. */
-                              , 0, false
-#endif
-                          );
-
-    poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
+//     poolPtr->array[asid & MASK(asidLowBits)] = asid_map;
 
     return EXCEPTION_NONE;
 }
 
 void increaseASIDBindCB(asid_t asid);
 void decreaseASIDBindCB(asid_t asid);
-
-#endif

--- a/include/arch/arm/arch/64/mode/machine/hardware.h
+++ b/include/arch/arm/arch/64/mode/machine/hardware.h
@@ -11,6 +11,38 @@
 
 #define PAGE_BITS seL4_PageBits
 
+/* Extract the n-level PT index from a virtual address:
+ * - n is page table level counting from the root page table,
+ * - NUM_PT_LEVELS are either 3 or 4 page table levels depending
+ *   on whether the address range being translated is 48bits, 44 bits or 40 bits.
+ * - If translating an address in the kernel addrspace NUM_PT_LEVELS = 4 always.
+ * - PageTables always have 512 slots (PT_INDEX_BITS = 9) but if there are only
+ *   3 total levels then the root level is implemented with 4 concatenated tables
+ *   meaning 2048 slots (UPT_LEVELS = 3 => seL4_VSpaceIndexBits = 12)
+ *
+ * PT_LEVEL_SHIFT(n) == PT_INDEX_BITS * (NUM_PT_LEVELS - n) + seL4_PageBits
+ * GET_PT_INDEX(addr, n) == (addr >> PT_LEVEL_SHIFT(n)) & MASK(PT_INDEX_BITS)
+ */
+#ifdef AARCH64_VSPACE_S2_START_L1
+#define UPT_LEVELS 3
+#define ULVL_FRM_ARM_PT_LVL(n) ((n)-1)
+#else
+#define UPT_LEVELS 4
+#define ULVL_FRM_ARM_PT_LVL(n) (n)
+#endif
+#define KPT_LEVELS 4
+#define KLVL_FRM_ARM_PT_LVL(n) (n)
+
+#define KPT_LEVEL_SHIFT(n) (((PT_INDEX_BITS) * (((KPT_LEVELS) - 1) - (n))) + seL4_PageBits)
+#define GET_KPT_INDEX(addr, n)  (((addr) >> KPT_LEVEL_SHIFT(n)) & MASK(PT_INDEX_BITS))
+#define GET_KLVL_PGSIZE(n)      BIT(KPT_LEVEL_SHIFT((n)))
+
+#define UPT_LEVEL_SHIFT(n) (((PT_INDEX_BITS) * (((UPT_LEVELS) - 1) - (n))) + seL4_PageBits)
+#define UPT_INDEX_MASK(n) (n == 0 ? seL4_VSpaceIndexBits : PT_INDEX_BITS)
+#define GET_UPT_INDEX(addr, n)  (((addr) >> UPT_LEVEL_SHIFT(n)) & MASK(UPT_INDEX_MASK(n)))
+#define GET_ULVL_PGSIZE_BITS(n) UPT_LEVEL_SHIFT((n))
+#define GET_ULVL_PGSIZE(n)      BIT(UPT_LEVEL_SHIFT((n)))
+
 /* Control register fields */
 #define CONTROL_M         0  /* MMU enable */
 #define CONTROL_A         1  /* Alignment check enable */

--- a/include/arch/arm/arch/64/mode/model/statedata.h
+++ b/include/arch/arm/arch/64/mode/model/statedata.h
@@ -22,10 +22,10 @@ extern asid_pool_t *armKSASIDTable[BIT(asidHighBits)] VISIBLE;
 /* This is the temporary userspace page table in kernel. It is required before running
  * user thread to avoid speculative page table walking with the wrong page table. */
 extern vspace_root_t armKSGlobalUserVSpace[BIT(seL4_VSpaceIndexBits)] VISIBLE;
-extern pgde_t armKSGlobalKernelPGD[BIT(PGD_INDEX_BITS)] VISIBLE;
+extern pte_t armKSGlobalKernelPGD[BIT(PT_INDEX_BITS)] VISIBLE;
 
-extern pude_t armKSGlobalKernelPUD[BIT(PUD_INDEX_BITS)] VISIBLE;
-extern pde_t armKSGlobalKernelPDs[BIT(PUD_INDEX_BITS)][BIT(PD_INDEX_BITS)] VISIBLE;
+extern pte_t armKSGlobalKernelPUD[BIT(PT_INDEX_BITS)] VISIBLE;
+extern pte_t armKSGlobalKernelPDs[BIT(PT_INDEX_BITS)][BIT(PT_INDEX_BITS)] VISIBLE;
 extern pte_t armKSGlobalKernelPT[BIT(PT_INDEX_BITS)] VISIBLE;
 
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT

--- a/include/arch/arm/arch/64/mode/object/structures.bf
+++ b/include/arch/arm/arch/64/mode/object/structures.bf
@@ -32,7 +32,7 @@ block frame_cap {
     padding                          6
 }
 
--- Forth-level page table
+-- Page table caps
 block page_table_cap {
     field capPTMappedASID            16
     field_high capPTBasePtr          48
@@ -44,47 +44,19 @@ block page_table_cap {
     padding                          20
 }
 
--- Third-level page table (page directory)
-block page_directory_cap {
-    field capPDMappedASID            16
-    field_high capPDBasePtr          48
+-- First-level page table (vspace_root)
+block vspace_cap {
+    field capVSMappedASID            16
+    field_high capVSBasePtr          48
 
     field capType                    5
-    padding                          10
-    field capPDIsMapped              1
-    field_high capPDMappedAddress    19
-    padding                          29
-}
-
--- Second-level page table (page upper directory)
-block page_upper_directory_cap {
-    field capPUDMappedASID           16
-    field_high capPUDBasePtr         48
-
-    field capType                    5
-    field capPUDIsMapped             1
-    field_high capPUDMappedAddress   10
-#if defined (CONFIG_ARM_SMMU)  && defined (AARCH64_VSPACE_S2_START_L1)
-    field capPUDMappedCB             8
-    padding                          40
-#else 
-    padding                          48
-#endif 
-}
-
--- First-level page table (page global directory)
-block page_global_directory_cap {
-    field capPGDMappedASID           16
-    field_high capPGDBasePtr         48
-
-    field capType                    5
-    field capPGDIsMapped             1
-#ifdef CONFIG_ARM_SMMU 
-    field capPGDMappedCB             8
+    field capVSIsMapped              1
+#ifdef CONFIG_ARM_SMMU
+    field capVSMappedCB              8
     padding                          50
-#else 
+#else
     padding                          58
-#endif 
+#endif
 }
 
 -- Cap to the table of 2^7 ASID pools
@@ -154,6 +126,15 @@ block cb_cap {
 
 #endif
 
+#ifdef CONFIG_ALLOW_SMC_CALLS
+block smc_cap {
+    field capSMCBadge 64
+
+    field capType  5
+    padding        59
+}
+#endif
+
 -- NB: odd numbers are arch caps (see isArchCap())
 tagged_union cap capType {
     -- 5-bit tag caps
@@ -176,9 +157,7 @@ tagged_union cap capType {
     -- 5-bit tag arch caps
     tag frame_cap                   1
     tag page_table_cap              3
-    tag page_directory_cap          5
-    tag page_upper_directory_cap    7
-    tag page_global_directory_cap   9
+    tag vspace_cap                  9
     tag asid_control_cap            11
     tag asid_pool_cap               13
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
@@ -189,6 +168,9 @@ tagged_union cap capType {
     tag sid_cap                     19
     tag cb_control_cap              21
     tag cb_cap                      23
+#endif
+#ifdef CONFIG_ALLOW_SMC_CALLS
+    tag smc_cap                     25
 #endif
 }
 
@@ -221,7 +203,8 @@ block VCPUFault {
 }
 
 block VPPIEvent {
-    field irq_w     64
+    padding         55
+    field irq_w      9
     padding         32
     padding         28
     field seL4_FaultType  4
@@ -271,93 +254,24 @@ tagged_union asid_map type {
 -- PGDE, PUDE, PDEs and PTEs, assuming 48-bit physical address
 base 64(48,0)
 
-block pgde_invalid {
-    padding                         62
-    field pgde_type                 2
-}
 
-block pgde_pud {
-    padding                         16
-    field_high pud_base_address     36
+-- See the definition of pte_type for explanation
+-- for pte_sw_type and pte_hw_type
+block pte_table {
+    padding                         5
+    field pte_sw_type               1
     padding                         10
-    field pgde_type                 2 -- must be 0b11
-}
-
-tagged_union pgde pgde_type {
-    tag pgde_invalid                0
-    tag pgde_pud                    3
-}
-
-block pude_invalid {
-    padding                         62
-    field pude_type                 2
-}
-
-block pude_1g {
-    padding                         9
-    field UXN                       1
-    padding                         6
-    field_high page_base_address    18
-    padding                         18
-    field nG                        1
-    field AF                        1
-    field SH                        2
-    field AP                        2
-#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-    field AttrIndx                  4
-#else
-    padding                         1
-    field AttrIndx                  3
-#endif
-    field pude_type                 2
-}
-
-block pude_pd {
-    padding                         16
-    field_high pd_base_address      36
-    padding                         10
-    field pude_type                 2
-}
-
-tagged_union pude pude_type {
-    tag pude_invalid                0
-    tag pude_1g                     1
-    tag pude_pd                     3
-}
-
-block pde_large {
-    padding                         9
-    field UXN                       1
-    padding                         6
-    field_high page_base_address    27
-    padding                         9
-    field nG                        1
-    field AF                        1
-    field SH                        2
-    field AP                        2
-#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-    field AttrIndx                  4
-#else
-    padding                         1
-    field AttrIndx                  3
-#endif
-    field pde_type                  2
-}
-
-block pde_small {
-    padding                         16
     field_high pt_base_address      36
     padding                         10
-    field pde_type                  2
+    field pte_hw_type               2
 }
 
-tagged_union pde pde_type {
-    tag pde_large                   1
-    tag pde_small                   3
-}
 
-block pte {
-    padding                         9
+-- The level 1 and 2 page pte structure
+block pte_page {
+    padding                         5
+    field pte_sw_type               1
+    padding                         3
     field UXN                       1
     padding                         6
     field_high page_base_address    36
@@ -371,8 +285,48 @@ block pte {
     padding                         1
     field AttrIndx                  3
 #endif
-    field reserved                  2 -- must be 0b11
+    field pte_hw_type               2
 }
+
+-- The level 3 page pte structure
+block pte_4k_page {
+    padding                         5
+    field pte_sw_type               1
+    padding                         3
+    field UXN                       1
+    padding                         6
+    field_high page_base_address    36
+    field nG                        1
+    field AF                        1
+    field SH                        2
+    field AP                        2
+#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+    field AttrIndx                  4
+#else
+    padding                         1
+    field AttrIndx                  3
+#endif
+    field pte_hw_type               2
+}
+
+block pte_invalid {
+    padding                         5
+    field pte_sw_type               1
+    padding                         56
+    field pte_hw_type               2
+}
+
+-- There are two page type fields because the 4k page size
+-- uses a different hardware encoding. We use bit 58
+-- which is reserved for software use to encode this
+-- difference in the tag for these types.
+tagged_union pte pte_type(pte_hw_type, pte_sw_type) {
+    tag pte_table               (3, 0)
+    tag pte_page                (1, 0)
+    tag pte_4k_page             (3, 1)
+    tag pte_invalid             (0, 0)
+}
+
 
 block ttbr {
     field asid                      16

--- a/include/arch/arm/arch/64/mode/object/structures.h
+++ b/include/arch/arm/arch/64/mode/object/structures.h
@@ -31,68 +31,25 @@ enum vm_rights {
 };
 typedef word_t vm_rights_t;
 
-/* If hypervisor support for aarch64 is enabled and we run on processors with
- * 40-bit PA, the stage-2 translation for EL1/EL0 uses a 3-level translation, skipping the PGD level.
- * Yet the kernel will still use a stage-1 translation with 48 bit input addresses and a 4-level
- * translation.  Therefore, PUD and PGD size for the kernel can be different from EL1/EL0
- * so we do not use the libsel4 definitions */
-#define PGD_SIZE_BITS       12
-#define PGD_INDEX_BITS      9
-#define PUD_SIZE_BITS       12
-#define PUD_INDEX_BITS      9
-#define UPUD_SIZE_BITS      seL4_PUDBits
-#define UPUD_INDEX_BITS     seL4_PUDIndexBits
-
-#define PDE_SIZE_BITS       seL4_PageDirEntryBits
-#define PD_INDEX_BITS       seL4_PageDirIndexBits
 #define PTE_SIZE_BITS       seL4_PageTableEntryBits
 #define PT_INDEX_BITS       seL4_PageTableIndexBits
 
 #define PT_INDEX_OFFSET     (seL4_PageBits)
-#define PD_INDEX_OFFSET     (PT_INDEX_OFFSET + PT_INDEX_BITS)
-#define PUD_INDEX_OFFSET    (PD_INDEX_OFFSET + PD_INDEX_BITS)
-#define PGD_INDEX_OFFSET    (PUD_INDEX_OFFSET + PUD_INDEX_BITS)
 
 #define VCPU_SIZE_BITS      seL4_VCPUBits
 
 #ifdef AARCH64_VSPACE_S2_START_L1
 /* For hyp with 40 bit PA, EL1 and EL0 use a 3 level translation and skips the PGD */
-typedef pude_t vspace_root_t;
+typedef pte_t vspace_root_t;
 #else
 /* Otherwise we use a 4-level translation */
-typedef pgde_t vspace_root_t;
+typedef pte_t vspace_root_t;
 #endif
 
 #define VSPACE_PTR(r)       ((vspace_root_t *)(r))
 
-#define GET_PGD_INDEX(x)    (((x) >> (PGD_INDEX_OFFSET)) & MASK(PGD_INDEX_BITS))
-#define GET_PUD_INDEX(x)    (((x) >> (PUD_INDEX_OFFSET)) & MASK(PUD_INDEX_BITS))
-#define GET_UPUD_INDEX(x)   (((x) >> (PUD_INDEX_OFFSET)) & MASK(UPUD_INDEX_BITS))
-#define GET_PD_INDEX(x)     (((x) >> (PD_INDEX_OFFSET)) & MASK(PD_INDEX_BITS))
-#define GET_PT_INDEX(x)     (((x) >> (PT_INDEX_OFFSET)) & MASK(PT_INDEX_BITS))
-
-#define PGDE_PTR(r)         ((pgde_t *)(r))
-#define PGDE_PTR_PTR(r)     ((pgde_t **)(r))
-#define PGDE_REF(p)         ((word_t)(p))
-
-#define PGD_PTR(r)          ((pgde_t *)(r))
-#define PGD_REF(p)          ((word_t)(r))
-
-#define PUDE_PTR(r)         ((pude_t *)(r))
-#define PUDE_PTR_PTR(r)     ((pude_t **)(r))
-#define PUDE_REF(p)         ((word_t)(p))
-
-#define PUD_PTR(r)          ((pude_t *)(r))
-#define PUD_PREF(p)         ((word_t)(p))
-
-#define PDE_PTR(r)          ((pde_t *)(r))
-#define PDE_PTR_PTR(r)      ((pde_t **)(r))
-#define PDE_REF(p)          ((word_t)(p))
-
-#define PD_PTR(r)           ((pde_t *)(r))
-#define PD_REF(p)           ((word_t)(p))
-
 #define PTE_PTR(r)          ((pte_t *)(r))
+#define PTE_PTR_PTR(r)      ((pte_t **)(r))
 #define PTE_REF(p)          ((word_t)(p))
 
 #define PT_PTR(r)           ((pte_t *)(r))
@@ -106,6 +63,11 @@ struct asid_pool {
     asid_map_t array[BIT(asidLowBits)];
 };
 typedef struct asid_pool asid_pool_t;
+
+/* Generic fastpath.c code expects pde_t for stored_hw_asid
+ * that's a workaround in the time being.
+ */
+typedef pte_t pde_t;
 
 #define ASID_POOL_PTR(r)    ((asid_pool_t*)r)
 #define ASID_POOL_REF(p)    ((word_t)p)
@@ -132,14 +94,8 @@ static inline word_t CONST cap_get_archCapSizeBits(cap_t cap)
     case cap_page_table_cap:
         return seL4_PageTableBits;
 
-    case cap_page_directory_cap:
-        return seL4_PageDirBits;
-
-    case cap_page_upper_directory_cap:
-        return seL4_PUDBits;
-
-    case cap_page_global_directory_cap:
-        return seL4_PGDBits;
+    case cap_vspace_cap:
+        return seL4_VSpaceBits;
 
     case cap_asid_pool_cap:
         return seL4_ASIDPoolBits;
@@ -172,13 +128,7 @@ static inline bool_t CONST cap_get_archCapIsPhysical(cap_t cap)
     case cap_page_table_cap:
         return true;
 
-    case cap_page_directory_cap:
-        return true;
-
-    case cap_page_upper_directory_cap:
-        return true;
-
-    case cap_page_global_directory_cap:
+    case cap_vspace_cap:
         return true;
 
     case cap_asid_pool_cap:
@@ -209,16 +159,10 @@ static inline void *CONST cap_get_archCapPtr(cap_t cap)
         return (void *)(cap_frame_cap_get_capFBasePtr(cap));
 
     case cap_page_table_cap:
-        return PD_PTR(cap_page_table_cap_get_capPTBasePtr(cap));
+        return PT_PTR(cap_page_table_cap_get_capPTBasePtr(cap));
 
-    case cap_page_directory_cap:
-        return PT_PTR(cap_page_directory_cap_get_capPDBasePtr(cap));
-
-    case cap_page_upper_directory_cap:
-        return PUD_PTR(cap_page_upper_directory_cap_get_capPUDBasePtr(cap));
-
-    case cap_page_global_directory_cap:
-        return PGD_PTR(cap_page_global_directory_cap_get_capPGDBasePtr(cap));
+	case cap_vspace_cap:
+        return VSPACE_PTR(cap_vspace_cap_get_capVSBasePtr(cap));
 
     case cap_asid_control_cap:
         return NULL;
@@ -236,61 +180,41 @@ static inline void *CONST cap_get_archCapPtr(cap_t cap)
         return NULL;
     }
 }
-
-static inline bool_t pgde_pgde_pud_ptr_get_present(pgde_t *pgd)
+static inline bool_t pte_pte_page_ptr_get_present(pte_t *pt)
 {
-    return (pgde_ptr_get_pgde_type(pgd) == pgde_pgde_pud);
+	return (pte_ptr_get_pte_type(pt) == pte_pte_page);
 }
 
-static inline bool_t pude_pude_pd_ptr_get_present(pude_t *pud)
+static inline bool_t pte_pte_table_ptr_get_present(pte_t *pt)
 {
-    return (pude_ptr_get_pude_type(pud) == pude_pude_pd);
+	return (pte_ptr_get_pte_type(pt) == pte_pte_table);
 }
 
-static inline bool_t pude_pude_1g_ptr_get_present(pude_t *pud)
+static inline bool_t pte_4k_page_ptr_get_present(pte_t *pt)
 {
-    return (pude_ptr_get_pude_type(pud) == pude_pude_1g);
+	return (pte_ptr_get_pte_type(pt) == pte_pte_4k_page);
 }
 
-static inline pude_t pude_invalid_new(void)
+static inline bool_t pte_ptr_get_valid(pte_t *pt)
 {
-    return (pude_t) {
-        {
-            0
-        }
-    };
+	return (pte_ptr_get_pte_type(pt) != pte_pte_invalid);
 }
 
-static inline bool_t pde_pde_small_ptr_get_present(pde_t *pd)
+static inline bool_t pte_is_page_type(pte_t pte)
 {
-    return (pde_ptr_get_pde_type(pd) == pde_pde_small);
+	return pte_get_pte_type(pte) == pte_pte_4k_page ||
+		pte_get_pte_type(pte) == pte_pte_page;
 }
 
-static inline bool_t pde_pde_large_ptr_get_present(pde_t *pd)
+/** Return base address for both of pte_4k_page and pte_page */
+static inline uint64_t pte_get_page_base_address(pte_t pte)
 {
-    return (pde_ptr_get_pde_type(pd) == pde_pde_large);
+	assert(pte_is_page_type(pte));
+	return pte.words[0] & 0xfffffffff000ull;
 }
 
-static inline pde_t pde_invalid_new(void)
+/** Return base address for both of pte_4k_page and pte_page */
+static inline uint64_t pte_page_ptr_get_page_base_address(pte_t *pt)
 {
-    return (pde_t) {
-        {
-            0
-        }
-    };
+	return pte_get_page_base_address(*pt);
 }
-
-static inline bool_t pte_ptr_get_present(pte_t *pt)
-{
-    return (pte_ptr_get_reserved(pt) == 0x3);
-}
-
-static inline pte_t pte_invalid_new(void)
-{
-    return (pte_t) {
-        {
-            0
-        }
-    };
-}
-

--- a/include/arch/arm/arch/kernel/vspace.h
+++ b/include/arch/arm/arch/kernel/vspace.h
@@ -31,7 +31,6 @@ extern char arm_vector_table[1];
 
 word_t *PURE lookupIPCBuffer(bool_t isReceiver, tcb_t *thread);
 exception_t handleVMFault(tcb_t *thread, vm_fault_type_t vm_faultType);
-pde_t *pageTableMapped(asid_t asid, vptr_t vaddr, pte_t *pt);
 void setVMRoot(tcb_t *tcb);
 bool_t CONST isValidVTableRoot(cap_t cap);
 exception_t checkValidIPCBuffer(vptr_t vptr, cap_t cap);
@@ -46,48 +45,3 @@ exception_t decodeARMMMUInvocation(word_t invLabel, word_t length, cptr_t cptr,
 void Arch_userStackTrace(tcb_t *tptr);
 #endif
 
-// MiDev Modifications
-
-
-struct lookupPGDSlot_ret {
-    exception_t status;
-    pgde_t *pgdSlot;
-};
-typedef struct lookupPGDSlot_ret lookupPGDSlot_ret_t;
-
-struct lookupPUDSlot_ret {
-    exception_t status;
-    pude_t *pudSlot;
-};
-typedef struct lookupPUDSlot_ret lookupPUDSlot_ret_t;
-
-struct lookupPDSlot_ret {
-    exception_t status;
-    pde_t *pdSlot;
-};
-typedef struct lookupPDSlot_ret lookupPDSlot_ret_t;
-
-struct lookupPTSlot_ret {
-    exception_t status;
-    pte_t *ptSlot;
-};
-typedef struct lookupPTSlot_ret lookupPTSlot_ret_t;
-
-struct lookupFrame_ret {
-    paddr_t frameBase;
-    vm_page_size_t frameSize;
-    bool_t valid;
-};
-typedef struct lookupFrame_ret lookupFrame_ret_t;
-
-struct findVSpaceForASID_ret {
-    exception_t status;
-    vspace_root_t *vspace_root;
-};
-typedef struct findVSpaceForASID_ret findVSpaceForASID_ret_t;
-
-void map_it_frame_cap(cap_t vspace_cap, cap_t frame_cap, bool_t executable);
-lookupPUDSlot_ret_t lookupPUDSlot(vspace_root_t *vspace, vptr_t vptr);
-lookupPGDSlot_ret_t lookupPGDSlot(vspace_root_t *vspace, vptr_t vptr);
-findVSpaceForASID_ret_t findVSpaceForASID(asid_t asid);
-lookupPDSlot_ret_t lookupPDSlot(vspace_root_t *vspace, vptr_t vptr);

--- a/include/arch/arm/arch/machine/gic_v3.h
+++ b/include/arch/arm/arch/machine/gic_v3.h
@@ -175,8 +175,8 @@ struct gic_dist_map {
                                      * interrupt routing for SPI 32 */
 };
 
-_Static_assert(0x6100 == SEL4_OFFSETOF(struct gic_dist_map, iroutern),
-               "Error in struct gic_dist_map");
+unverified_compile_assert(error_in_gic_dist_map,
+                          0x6100 == __builtin_offsetof(struct gic_dist_map, iroutern));
 
 /* Memory map for GIC Redistributor Registers for control and physical LPI's */
 struct gic_rdist_map {          /* Starting */

--- a/libsel4/CMakeLists.txt
+++ b/libsel4/CMakeLists.txt
@@ -54,17 +54,22 @@ add_config_library(sel4 "${configure_string}")
 # Currently we use autoconf.h, so generate one of those
 generate_autoconf(sel4_autoconf "kernel;sel4")
 
-gen_invocation_header(OUTPUT include/sel4/invocation.h XML include/interfaces/sel4.xml LIBSEL4)
+gen_invocation_header(
+    OUTPUT include/sel4/invocation.h
+    XML include/interfaces/object-api.xml
+    LIBSEL4
+)
 
 gen_invocation_header(
     OUTPUT sel4_arch_include/${KernelSel4Arch}/sel4/sel4_arch/invocation.h
-    XML "${CMAKE_CURRENT_SOURCE_DIR}/sel4_arch_include/${KernelSel4Arch}/interfaces/sel4arch.xml"
+    XML
+        "${CMAKE_CURRENT_SOURCE_DIR}/sel4_arch_include/${KernelSel4Arch}/interfaces/object-api-sel4-arch.xml"
     LIBSEL4 SEL4ARCH
 )
 
 gen_invocation_header(
     OUTPUT arch_include/${KernelArch}/sel4/arch/invocation.h
-    XML "${CMAKE_CURRENT_SOURCE_DIR}/arch_include/${KernelArch}/interfaces/sel4arch.xml"
+    XML "${CMAKE_CURRENT_SOURCE_DIR}/arch_include/${KernelArch}/interfaces/object-api-arch.xml"
     LIBSEL4 ARCH
 )
 
@@ -84,14 +89,9 @@ include_directories("$<TARGET_PROPERTY:sel4_autoconf,INTERFACE_INCLUDE_DIRECTORI
 function(genbf target_prefix pbf_location bf_location header_output)
     get_generated_files(gen_list sel4_autoconf_Gen)
     cppfile(
-        "${pbf_location}"
-        ${target_prefix}_pbf
-        "${bf_location}"
-        EXTRA_FLAGS
-        -P
-        EXTRA_DEPS
-        sel4_autoconf_Gen
-        ${gen_list}
+        "${pbf_location}" ${target_prefix}_pbf "${bf_location}"
+        EXTRA_FLAGS -P
+        EXTRA_DEPS sel4_autoconf_Gen ${gen_list}
     )
     GenHBFTarget(
         "libsel4"
@@ -122,6 +122,9 @@ genbf(
 if(KernelIsMCS)
     set(mcs --mcs)
 endif()
+if(KernelX86_64VTX64BitGuests)
+    set(64bitguests --x86-vtx-64-bit-guests)
+endif()
 add_custom_command(
     OUTPUT include/sel4/syscall.h
     COMMAND rm -f include/sel4/syscall.h
@@ -144,23 +147,18 @@ add_custom_command(
 
 set(
     interface_xmls
-    "${CMAKE_CURRENT_SOURCE_DIR}/sel4_arch_include/${KernelSel4Arch}/interfaces/sel4arch.xml"
-    "${CMAKE_CURRENT_SOURCE_DIR}/arch_include/${KernelArch}/interfaces/sel4arch.xml"
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/interfaces/sel4.xml"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sel4_arch_include/${KernelSel4Arch}/interfaces/object-api-sel4-arch.xml"
+    "${CMAKE_CURRENT_SOURCE_DIR}/arch_include/${KernelArch}/interfaces/object-api-arch.xml"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/interfaces/object-api.xml"
 )
+
 add_custom_command(
     OUTPUT include/interfaces/sel4_client.h
     COMMAND rm -f include/interfaces/sel4_client.h
     COMMAND
-        echo "CONFIG_WORD_SIZE=${KernelWordSize}" > config
-    COMMAND
-        "${PYTHON3}" "${SYSCALL_STUB_GEN_PATH}" ${buffer} ${mcs} -a "${KernelSel4Arch}" -c config -o
-        include/interfaces/sel4_client.h ${interface_xmls}
-    DEPENDS
-        "${SYSCALL_STUB_GEN_PATH}"
-        ${interface_xmls}
-        BYPRODUCTS
-        config
+        "${PYTHON3}" "${SYSCALL_STUB_GEN_PATH}" ${buffer} ${64bitguests} ${mcs} -a
+        "${KernelSel4Arch}" -o include/interfaces/sel4_client.h ${interface_xmls}
+    DEPENDS "${SYSCALL_STUB_GEN_PATH}" ${interface_xmls}
     COMMENT "Generate sel4_client.h"
     VERBATIM
 )

--- a/libsel4/arch_include/arm/interfaces/object-api-arch.xml
+++ b/libsel4/arch_include/arm/interfaces/object-api-arch.xml
@@ -1,0 +1,1116 @@
+<?xml version="1.0" ?>
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: BSD-2-Clause
+-->
+
+<api name="ObjectApiArm" label_prefix="arm_">
+    <interface name="seL4_ARM_PageTable" manual_name="Page Table"
+        cap_description="Capability to the page table being operated on.">
+        <method id="ARMPageTableMap" name="Map" manual_label="pagetable_map">
+            <brief>
+                Map a page table into an address space.
+            </brief>
+            <description>
+                Takes a VSpace capability as an argument, and installs a
+                reference to the page table in the VSpace at the provided
+                virtual address.
+            </description>
+            <param dir="in" name="vspace" type="seL4_CPtr"
+            description="Capability to the VSpace which will contain the mapping.
+                Must be assigned to an ASID pool."/>
+            <param dir="in" name="vaddr" type="seL4_Word"
+            description="Virtual address to map the page into."/>
+            <param dir="in" name="attr" type="seL4_ARM_VMAttributes">
+                <description>
+                    VM Attributes for the mapping. <docref>Possible values for this type are given in <autoref label="ch:vspace"/>  .</docref>
+                </description>
+            </param>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    A mapping already exists for this level in <texttt text="vspace"/> at <texttt text="vaddr."/>
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    On aarch64, <texttt text="vspace"/> does not have a Page Directory mapped at <texttt text="vaddr"/>.
+                    Or, <texttt text="vspace"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="vaddr"/> is in the kernel virtual address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="vspace"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="vspace"/> is not assigned to an ASID pool.
+                    Or, <texttt text="_service"/> is already mapped in a VSpace.
+                </description>
+            </error>
+        </method>
+        <method id="ARMPageTableUnmap" name="Unmap" manual_label="pagetable_unmap">
+            <brief>
+                Unmap a page table from its <texttt text="Page Directory"/> and zero it out.
+            </brief>
+            <description>
+                Removes the reference to the invoked <texttt text="Page Table"/> from its
+                containing <texttt text="Page Directory"/>.
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    A copy of the <texttt text="_service"/> capability exists.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_ARM_IOPageTable" manual_name="I/O Page Table"
+        cap_description="Capability to the I/O page table being operated on.">
+        <method id="ARMIOPageTableMap" name="Map">
+            <condition><config var="CONFIG_TK1_SMMU"/></condition>
+            <brief>
+                Map an IO page table into an IOSpace.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:iospace"/></docref>
+            </description>
+            <param dir="in" name="iospace" type="seL4_ARM_IOSpace" description="The IOSpace to map the page table into."/>
+            <param dir="in" name="ioaddr" type="seL4_Word" description="Virtual address at which to map the page table."/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    All required page tables are already mapped in <texttt text="iospace"/> at <texttt text="ioaddr"/>.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="iospace"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is already mapped in an IOSpace.
+                </description>
+            </error>
+        </method>
+        <method id="ARMIOPageTableUnmap" name="Unmap">
+            <condition><config var="CONFIG_TK1_SMMU"/></condition>
+            <brief>
+                Unmap an IO page table from an IOSpace.
+            </brief>
+            <description>
+                <docref>See <autoref label="ch:vspace"/></docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_ARM_Page" manual_name="Page"
+        cap_description="Capability to the page being operated on.">
+        <method id="ARMPageMap" name="Map">
+            <brief>
+                Map a page into an address space or update the mapping attributes.
+            </brief>
+            <description>
+                Takes a VSpace capability as an argument and installs a reference
+                to the given <texttt text="Page"/> in the lowest-level unmapped paging structure
+                corresponding to the given address, or updates the mapping attributes if the page is
+                already mapped at this address. The page must not already be mapped through this
+                capability in a different VSpace or at a different address; the page may be mapped
+                in multiple VSpaces by copying the capability.
+            </description>
+            <param dir="in" name="vspace" type="seL4_CPtr"
+            description="Capability to the VSpace which will contain the mapping.
+                Must be assigned to an ASID pool."/>
+            <param dir="in" name="vaddr" type="seL4_Word"
+            description="Virtual address to map the page into."/>
+            <param dir="in" name="rights" type="seL4_CapRights_t">
+                <description>
+                    Rights for the mapping.<docref> Possible values for this type are given in <autoref label="sec:cap_rights"/>  .</docref>
+                </description>
+            </param>
+            <param dir="in" name="attr" type="seL4_ARM_VMAttributes">
+                <description>
+                    VM Attributes for the mapping.<docref> Possible values for this type are given in <autoref label="ch:vspace"/>  .</docref>
+                </description>
+            </param>
+            <error name="seL4_AlignmentError">
+                <description>
+                    The <texttt text="vaddr"/> is not aligned to the page size of <texttt text="_service"/>.
+                </description>
+            </error>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    A mapping already exists in <texttt text="vspace"/> at <texttt text="vaddr"/>.
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="vspace"/> does not have a paging structure at the required level mapped at <texttt text="vaddr"/>.
+                    Or, <texttt text="vspace"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="_service"/> is already mapped in <texttt text="vspace"/> at a different virtual address.
+                    Or, <texttt text="vaddr"/> is in the kernel virtual address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="vspace"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="vspace"/> is not assigned to an ASID pool.
+                    Or, <texttt text="_service"/> is already mapped in a different VSpace.
+                </description>
+            </error>
+        </method>
+        <method id="ARMPageUnmap" name="Unmap">
+            <brief>
+                Unmap a page.
+            </brief>
+            <description>
+                Removes an existing mapping.
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="ARMPageMapIO" name="MapIO" manual_name="Map I/O">
+            <condition><config var="CONFIG_TK1_SMMU"/></condition>
+            <brief>
+                Map a page into an IOSpace.
+            </brief>
+            <description>
+                <docref>See <autoref label="ch:vspace"/></docref>
+            </description>
+            <param dir="in" name="iospace" type="seL4_ARM_IOSpace" description="The IOSpace to map the page into."/>
+            <param dir="in" name="rights" type="seL4_CapRights_t">
+                <description>
+                    Rights for the mapping.<docref> Possible values for this type are given in <autoref label="sec:cap_rights"/>  .</docref>
+                </description>
+            </param>
+            <param dir="in" name="ioaddr" type="seL4_Word" description="Virtual address at which to map page."/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    A mapping already exists in <texttt text="iospace"/> at <texttt text="ioaddr"/>.
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="iospace"/> does not have a sufficient number of IO Page Tables mapped at <texttt text="ioaddr"/>.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    No rights were specified in <texttt text="rights"/>.
+                    Or, the rights in the <texttt text="_service"/> capability do not include <texttt text="rights"/>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="iospace"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is already mapped.
+                    Or, <texttt text="_service"/> is not a page of size 4 KiB.
+                </description>
+            </error>
+        </method>
+        <method id="ARMPageClean_Data" name="Clean_Data" manual_name="Clean Data">
+            <brief>
+                Cleans the data cache out to RAM. The start and end are relative to the page being serviced.
+            </brief>
+            <description>
+                <docref>See <autoref label="ch:vspace"/>.</docref>
+            </description>
+            <param dir="in" name="start_offset" type="seL4_Word"
+            description="The offset, relative to the start of the page inclusive."/>
+            <param dir="in" name="end_offset" type="seL4_Word"
+            description="The offset, relative to the start of the page exclusive."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The VSpace of <texttt text="_service"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not mapped in a VSpace.
+                    Or, if hypervisor support is configured, the requested range overlaps the kernel physical address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="start_offset"/> is greater than or equal to <texttt text="end_offset"/>.
+                    Or, <texttt text="start_offset"/> or <texttt text="end_offset"/> exceeds the page size of <texttt text="_service"/>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="ARMPageInvalidate_Data" name="Invalidate_Data" manual_name="Invalidate Data">
+            <brief>
+                Invalidates the cache range within the given page. The start and end offsets are relative to the page being serviced
+                and should be aligned to a cache line boundary where possible.
+                An additional clean is performed on the outer cache lines if the start and end are
+                not aligned, to clean out the bytes between the requested and the cache line boundary.
+            </brief>
+            <description>
+                <docref>See <autoref label="ch:vspace"/>.</docref>
+            </description>
+            <param dir="in" name="start_offset" type="seL4_Word"
+            description="The offset, relative to the start of the page inclusive."/>
+            <param dir="in" name="end_offset" type="seL4_Word"
+            description="The offset, relative to the start of the page exclusive."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The VSpace of <texttt text="_service"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not mapped in a VSpace.
+                    Or, if hypervisor support is configured, the requested range overlaps the kernel physical address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="start_offset"/> is greater than or equal to <texttt text="end_offset"/>.
+                    Or, <texttt text="start_offset"/> or <texttt text="end_offset"/> exceeds the page size of <texttt text="_service"/>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="ARMPageCleanInvalidate_Data" name="CleanInvalidate_Data"
+            manual_name="Clean and Invalidate Data">
+            <brief>
+                Clean and invalidates the cache range within the given page. The range will be flushed out to RAM.
+                The start and end offsets are relative to the page being serviced.
+            </brief>
+            <description>
+                <docref>See <autoref label="ch:vspace"/>.</docref>
+            </description>
+            <param dir="in" name="start_offset" type="seL4_Word"
+            description="The offset, relative to the start of the page inclusive."/>
+            <param dir="in" name="end_offset" type="seL4_Word"
+            description="The offset, relative to the start of the page exclusive."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The VSpace of <texttt text="_service"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not mapped in a VSpace.
+                    Or, if hypervisor support is configured, the requested range overlaps the kernel physical address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="start_offset"/> is greater than or equal to <texttt text="end_offset"/>.
+                    Or, <texttt text="start_offset"/> or <texttt text="end_offset"/> exceeds the page size of <texttt text="_service"/>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="ARMPageUnify_Instruction" name="Unify_Instruction" manual_name="Unify Instruction">
+            <brief>
+                Unify Instruction Cache. Cleans data lines to point of unification, invalidate
+                corresponding instruction lines to point of unification, then invalidates branch
+                predictors. The start and end offsets are relative to the page being
+                serviced.
+            </brief>
+            <description>
+                <docref>See <autoref label="ch:vspace"/>.</docref>
+            </description>
+            <param dir="in" name="start_offset" type="seL4_Word"
+            description="The offset, relative to the start of the page inclusive."/>
+            <param dir="in" name="end_offset" type="seL4_Word"
+            description="The offset, relative to the start of the page exclusive."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The VSpace of <texttt text="_service"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not mapped in a VSpace.
+                    Or, if hypervisor support is configured, the requested range overlaps the kernel physical address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="start_offset"/> is greater than or equal to <texttt text="end_offset"/>.
+                    Or, <texttt text="start_offset"/> or <texttt text="end_offset"/> exceeds the page size of <texttt text="_service"/>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="ARMPageGetAddress" name="GetAddress" manual_name="Get Address">
+            <brief>
+                Get the physical address of the underlying frame.
+            </brief>
+            <description>
+                <docref>See <autoref label="ch:vspace"/>.</docref>
+            </description>
+            <return>
+                A <texttt text='seL4_ARM_Page_GetAddress_t'/> struct that contains a
+                <texttt text='seL4_Word paddr'/>, which holds the physical address of the page,
+                and <texttt text='int error'/>.<docref> See <autoref label='sec:errors'/> for a description
+                of the message register and tag contents upon error.</docref>
+            </return>
+            <param dir="out" name="paddr" type="seL4_Word"/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_ARM_ASIDControl" manual_name="ASID Control"
+        cap_description="The master ASIDControl capability being operated on.">
+        <method id="ARMASIDControlMakePool" name="MakePool" manual_name="Make Pool">
+            <brief>
+                Create an ASID Pool.
+            </brief>
+            <description>
+                Together with a capability to <texttt text="Untyped Memory"/>, which is passed as an argument,
+                create an <texttt text="ASID Pool"/>. The untyped capability must represent a
+                4K memory object. This will create an ASID pool with enough space for 1024 VSpaces.
+            </description>
+            <param dir="in" name="untyped" type="seL4_Untyped"
+            description="Capability to an untyped memory object that will become the pool. Must be 4K bytes."/>
+            <param dir="in" name="root" type="seL4_CNode"
+            description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="index" type="seL4_Word"
+            description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
+            <param dir="in" name="depth" type="seL4_Uint8"
+            description="Number of bits of index to resolve to find the destination slot."/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    The destination slot contains a capability.
+                    Or, there are no more ASID pools available.
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="index"/> or <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="root"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="untyped"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="untyped"/> is not the exact size of an ASID pool object.
+                    Or, <texttt text="untyped"/> is a device untyped <docref>(see <autoref label="sec:kernmemalloc"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    The <texttt text="untyped"/> has been used to retype an object.
+                    Or, a copy of the <texttt text="untyped"/> capability exists.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_ARM_ASIDPool" manual_name="ASID Pool"
+        cap_description="The ASID pool which is being assigned to. Must not be full. Each ASID pool can contain 1024 entries.">
+        <method id="ARMASIDPoolAssign" name="Assign" manual_label="asidpool_assign"
+            manual_name="ASID Pool Assign">
+            <brief>
+                Assign an ASID Pool.
+            </brief>
+            <description>
+                Assigns an ASID to the VSpace passed in as an argument.
+            </description>
+            <param dir="in" name="vspace" type="seL4_CPtr"
+            description="The VSpace that is being assigned to an ASID pool. Must not already be assigned to an ASID pool."/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    There are no more ASIDs available in <texttt text="_service"/>.
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The ASID pool of <texttt text="_service"/> is no longer assigned.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="vspace"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="vspace"/> is already assigned to an ASID pool.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_ARM_VCPU" manual_name="VCPU"
+        cap_description="Capability to the VCPU being operated on.">
+        <method id="ARMVCPUSetTCB" name="SetTCB" manual_name="Set TCB">
+            <condition><config var="CONFIG_ARM_HYPERVISOR_SUPPORT"/></condition>
+            <brief>
+                Bind a TCB to a virtual CPU.
+            </brief>
+             <description>
+                 There is a 1:1 relationship between a virtual CPU and a TCB. If either (or both) of them is
+                 associated with another one, they will be dissociated, and then associated to the
+                 ones called in this system calls.
+             </description>
+            <param dir="in" name="tcb" type="seL4_TCB"
+            description="Capability to TCB to bind to a virtual CPU"/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="tcb"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="ARMVCPUInjectIRQ" name="InjectIRQ" manual_name="Inject IRQ">
+            <condition><config var="CONFIG_ARM_HYPERVISOR_SUPPORT"/></condition>
+            <brief>
+                Inject an IRQ to a virtual CPU.
+            </brief>
+            <description>
+                Used to queue IRQs towards the VCPU.
+                Writes <texttt text="ICH_LRn_EL2"/> for GICv3 or <texttt text="LRn"/> for GICv2,
+                where <texttt text="n"/> is determined by <texttt text="index"/>.
+                The list register becomes available again when the guest acknowledges
+                the injected interrupt.
+            </description>
+            <param dir="in" name="virq" type="seL4_Uint16"
+            description="Virtual IRQ ID"/>
+            <param dir="in" name="priority" type="seL4_Uint8"
+            description="Priority of the IRQ to be injected"/>
+            <param dir="in" name="group" type="seL4_Uint8"
+            description="IRQ group"/>
+            <param dir="in" name="index" type="seL4_Uint8"
+            description="VGIC list register"/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    The <texttt text="index"/> is in use and not yet handled by the guest.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="virq"/>, <texttt text="priority"/>, <texttt text="group"/>, or <texttt text="index"/> is invalid.
+                </description>
+            </error>
+        </method>
+        <method id="ARMVCPUReadReg" name="ReadRegs" manual_name="Read Registers">
+            <condition><config var="CONFIG_ARM_HYPERVISOR_SUPPORT"/></condition>
+            <brief>
+                Read a virtual CPU register.
+            </brief>
+            <description>
+                Provides a way to read EL1 system registers, as well as <texttt text='VMPIDR_EL2'/>.
+            </description>
+            <return>
+                A <texttt text='seL4_ARM_VCPU_ReadRegs_t'/> struct that contains a
+                <texttt text='seL4_Word value'/>, which holds the value of the system register,
+                and <texttt text='int error'/>, which will be non-zero when an error occurred.
+                <docref>See <autoref label='sec:errors'/> for a description
+                of the message register and tag contents upon error.</docref>
+            </return>
+            <param dir="in" name="field" type="seL4_VCPUReg"
+            description="Register to read from a VCPU"/>
+            <param dir="out" name="value" type="seL4_Word"
+            description="Returned value of the VCPU register"/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="field"/> is invalid.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="ARMVCPUWriteReg" name="WriteRegs" manual_name="Write Registers">
+            <condition><config var="CONFIG_ARM_HYPERVISOR_SUPPORT"/></condition>
+            <brief>
+                Write a virtual CPU register.
+            </brief>
+            <description>
+                Provides a way to write EL1 system registers, as well as <texttt text='VMPIDR_EL2'/>.
+            </description>
+            <param dir="in" name="field" type="seL4_VCPUReg"
+            description="Register ID to write to a VCPU"/>
+            <param dir="in" name="value" type="seL4_Word"
+            description="Value to be written to the VCPU register"/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="field"/> is invalid.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="ARMVCPUAckVPPI" name="AckVPPI" manual_name="Acknowledge Virtual PPI IRQ">
+            <condition><config var="CONFIG_ARM_HYPERVISOR_SUPPORT"/></condition>
+            <brief>
+                Acknowledge a PPI IRQ previously forwarded from a VPPIEvent fault.
+            </brief>
+            <description>
+                Acknowledge and unmask the PPI interrupt so that further interrupts can be forwarded
+                through VPPIEvent faults.
+            </description>
+            <param dir="in" name="irq" type="seL4_Word"
+            description="irq to ack."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="irq"/> is invalid.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+    </interface>
+   <interface name="seL4_IRQControl" manual_name="IRQ Control" cap_description="An IRQControl capability. This gives you the authority to make this call.">
+
+       <method id="ARMIRQIssueIRQHandlerTrigger" name="GetTrigger" manual_name="Get IRQ Handler with Trigger Type"
+           manual_label="irq_controlgettrigger">
+            <brief>
+                Create an IRQ handler capability and specify the trigger method (edge or level).
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:interrupts"/>.</docref>
+            </description>
+            <param dir="in" name="irq" type="seL4_Word" description="The IRQ that you want this capability to handle."/>
+
+            <param dir="in" name="trigger" type="seL4_Word" description="Indicates whether this IRQ is edge (1) or level (0) triggered."/>
+            <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    The destination slot contains a capability.
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="index"/> or <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="root"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, the platform does not support setting the IRQ trigger.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="irq"/> is invalid.
+                    Or, <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    An IRQ handler capability for <texttt text="irq"/> has already been created.
+                </description>
+            </error>
+        </method>
+
+       <method id="ARMIRQIssueIRQHandlerTriggerCore" name="GetTriggerCore" manual_name="Get IRQ Handler (SMP)"
+           manual_label="irq_controlgettriggercore">
+            <condition><config var="CONFIG_ENABLE_SMP_SUPPORT"/></condition>
+            <brief>
+                Create an IRQ handler capability and specify the trigger method (edge or level) and the target core.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:interrupts"/>.</docref>
+            </description>
+            <param dir="in" name="irq" type="seL4_Word" description="The IRQ that you want this capability to handle."/>
+
+            <param dir="in" name="trigger" type="seL4_Word" description="Indicates whether this IRQ is edge (1) or level (0) triggered."/>
+            <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
+            <param dir="in" name="target" type="seL4_Word" description="Indicates the target core ID to which this IRQ will be sent."/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    The destination slot contains a capability.
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="index"/> or <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="root"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, SMP support is not enabled.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="target"/> is invalid.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    An IRQ handler capability for <texttt text="irq"/> has already been created.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_ARM_SIDControl" manual_name="SID Control" cap_description="A SIDControl capability. This gives you the authority to make this call.">
+       <method id="ARMSIDIssueSIDManager" name="GetSID" manual_name="Get SID" manual_label="sid_controlgetsid">
+            <condition><config var="CONFIG_ARM_SMMU"/></condition>
+            <brief>
+                Create a SID capability.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:smmuv2-creating-sel4-arm-sid-capabilities"/>.</docref>
+            </description>
+            <param dir="in" name="sid" type="seL4_Word" description="The SID that you want this capability to manage."/>
+            <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    The destination slot contains a capability.
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="index"/> or <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="root"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="sid"/> is invalid.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    An SID capability for <texttt text="sid"/> has already been created.
+                </description>
+            </error>
+        </method>
+       <method id="ARMSIDGetFault" name="GetFault" manual_name="Get Fault" manual_label="sid_controlgetfault">
+            <condition><config var="CONFIG_ARM_SMMU"/></condition>
+            <brief>
+                Get the fault status of the SMMU.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:smmuv2-fault-handling"/>.</docref>
+            </description>
+            <return>
+                A <texttt text='seL4_ARM_SMMU_GetFault_t'/> struct that contains a
+                <texttt text='seL4_Word status'/>, which holds the global fault status of the SMMU,
+                <texttt text='seL4_Word syndrome_0'/>, which holds the global fault syndrome 0 of the SMMU,
+                <texttt text='seL4_Word syndrome_1'/>, which holds the global fault syndrome 1 of the SMMU,
+                and <texttt text='int error'/>.<docref> See <autoref label='sec:errors'/> for a description
+                of the message register and tag contents upon error.</docref>
+            </return>
+            <param dir="out" name="status" type="seL4_Word"/>
+            <param dir="out" name="syndrome_0" type="seL4_Word"/>
+            <param dir="out" name="syndrome_1" type="seL4_Word"/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="ARMSIDClearFault" name="ClearFault" manual_name="Clear Fault" manual_label="sid_controlclearfault">
+            <condition><config var="CONFIG_ARM_SMMU"/></condition>
+            <brief>
+                Clear the fault status of the SMMU.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:smmuv2-fault-handling"/>.</docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_ARM_SID" manual_name="SID" cap_description="A SID capability. This gives you the authority to make this call.">
+       <method id="ARMSIDBindCB" name="BindCB" manual_name="Bind CB" manual_label="sid_bindcb">
+            <condition><config var="CONFIG_ARM_SMMU"/></condition>
+            <brief>
+                Binding a context bank to a stream ID.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:smmuv2-configuring-streams-transactions"/>.</docref>
+            </description>
+           <param dir="in" name="cb" type="seL4_CPtr"
+            description="The CB that is being binded to a stream ID. Must already has an assigned vspace."/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    The <texttt text="_service"/> is already bound to a context bank.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="cb"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="cb"/> is not assigned to a VSpace.
+                </description>
+            </error>
+        </method>
+       <method id="ARMSIDUnbindCB" name="UnbindCB" manual_name="Unbind CB" manual_label="sid_unbindcb">
+            <condition><config var="CONFIG_ARM_SMMU"/></condition>
+            <brief>
+                Unbinding a context bank from a stream ID.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:smmuv2-configuring-streams-transactions"/>.</docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not bound to a context block.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_ARM_CBControl" manual_name="CB Control" cap_description="A CBControl capability. This gives you the authority to make this call.">
+       <method id="ARMCBIssueCBManager" name="GetCB" manual_name="Get CB" manual_label="cb_controlgetcb">
+            <condition><config var="CONFIG_ARM_SMMU"/></condition>
+            <brief>
+                Create a CB capability.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:smmuv2-creating-sel4-arm-cb-capabilities"/>.</docref>
+            </description>
+            <param dir="in" name="cb" type="seL4_Word" description="The CB that you want this capability to manage."/>
+            <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    The destination slot contains a capability.
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="index"/> or <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="root"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="cb"/> is invalid.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    A CB capability for <texttt text="cb"/> has already been created.
+                </description>
+            </error>
+        </method>
+        <method id="ARMCBTLBInvalidateAll" name="TLBInvalidateAll" manual_name="TLB Invalidate All"
+           manual_label="cb_controltlbinvalidate">
+            <condition><config var="CONFIG_ARM_SMMU"/></condition>
+            <brief>
+                Invalidate all TLB entries.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:smmuv2-tlb-invalidation"/>.</docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_ARM_CB" manual_name="CB" cap_description="A CB capability. This gives you the authority to make this call.">
+       <method id="ARMCBAssignVspace" name="AssignVspace" manual_name="Assign VSpace" manual_label="cb_assignvspace">
+            <condition><config var="CONFIG_ARM_SMMU"/></condition>
+            <brief>
+                Assigning a VSpace to a context bank.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:smmuv2-configuring-context-banks"/>.</docref>
+            </description>
+           <param dir="in" name="vspace" type="seL4_CPtr"
+            description="The VSpace that is being assigned to a context bank. Must already has an assigned ASID."/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    The <texttt text="_service"/> is already assigned to a VSpace.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="vspace"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="vspace"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+        </method>
+        <method id="ARMCBUnassignVspace" name="UnassignVspace" manual_name="Unassign VSpace" manual_label="cb_unassignvspace">
+            <condition><config var="CONFIG_ARM_SMMU"/></condition>
+            <brief>
+                Unassigning a VSpace to a context bank.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:smmuv2-configuring-context-banks"/>.</docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not assigned to a VSpace.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="ARMCBTLBInvalidate" name="TLBInvalidate" manual_name="TLB Invalidate" manual_label="cb_tlbinvalidate">
+            <condition><config var="CONFIG_ARM_SMMU"/></condition>
+            <brief>
+                Invalidating TLB entries used by the current ASID in this context bank.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:smmuv2-tlb-invalidation"/>.</docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not assigned to a VSpace.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="ARMCBGetFault" name="CBGetFault" manual_name="CB Get Fault"
+           manual_label="cb_getfault">
+            <condition><config var="CONFIG_ARM_SMMU"/></condition>
+            <brief>
+                Get the fault status of the context bank.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:smmuv2-fault-handling"/>.</docref>
+            </description>
+            <return>
+                A <texttt text='seL4_ARM_SMMU_CB_GetFault_t'/> struct that contains a
+                <texttt text='seL4_Word status'/>, which holds the fault status of the context bank,
+                <texttt text='seL4_Word address'/>, which holds the faulty address,
+                and <texttt text='int error'/>.<docref> See <autoref label='sec:errors'/> for a description
+                of the message register and tag contents upon error.</docref>
+            </return>
+            <param dir="out" name="status" type="seL4_Word"/>
+            <param dir="out" name="address" type="seL4_Word"/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="ARMCBClearFault" name="CBClearFault" manual_name="CB Clear Fault" manual_label="cb_clearfault">
+            <condition><config var="CONFIG_ARM_SMMU"/></condition>
+            <brief>
+                 Clear the fault status of the context bank.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:smmuv2-fault-handling"/>.</docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+    </interface>
+</api>

--- a/libsel4/arch_include/arm/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/arm/sel4/arch/objecttype.h
@@ -16,7 +16,6 @@ typedef enum _object {
     seL4_ARM_SuperSectionObject,
 #endif
     seL4_ARM_PageTableObject,
-    seL4_ARM_PageDirectoryObject,
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     seL4_ARM_VCPUObject,
 #endif

--- a/libsel4/arch_include/arm/sel4/arch/types.h
+++ b/libsel4/arch_include/arm/sel4/arch/types.h
@@ -22,6 +22,7 @@ typedef seL4_CPtr seL4_ARM_SIDControl;
 typedef seL4_CPtr seL4_ARM_SID;
 typedef seL4_CPtr seL4_ARM_CBControl;
 typedef seL4_CPtr seL4_ARM_CB;
+typedef seL4_CPtr seL4_ARM_SMC;
 
 typedef enum {
     seL4_ARM_PageCacheable = 0x01,

--- a/libsel4/arch_include/riscv/interfaces/object-api-arch.xml
+++ b/libsel4/arch_include/riscv/interfaces/object-api-arch.xml
@@ -1,0 +1,371 @@
+<?xml version="1.0" ?>
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+     Copyright 2015, 2016 Hesham Almatary <heshamelmatary@gmail.com>
+
+     SPDX-License-Identifier: BSD-2-Clause
+-->
+
+<api name="ObjectApiRISCV" label_prefix="riscv_">
+
+    <struct name="seL4_UserContext">
+            <member name="pc"/>
+            <member name="ra"/>
+            <member name="sp"/>
+            <member name="gp"/>
+            <member name="s0"/>
+            <member name="s1"/>
+            <member name="s2"/>
+            <member name="s3"/>
+            <member name="s4"/>
+            <member name="s5"/>
+            <member name="s6"/>
+            <member name="s7"/>
+            <member name="s8"/>
+            <member name="s9"/>
+            <member name="s10"/>
+            <member name="s11"/>
+            <member name="a0"/>
+            <member name="a1"/>
+            <member name="a2"/>
+            <member name="a3"/>
+            <member name="a4"/>
+            <member name="a5"/>
+            <member name="a6"/>
+            <member name="a7"/>
+            <member name="t0"/>
+            <member name="t1"/>
+            <member name="t2"/>
+            <member name="t3"/>
+            <member name="t4"/>
+            <member name="t5"/>
+            <member name="t6"/>
+            <member name="tp"/>
+    </struct>
+    <interface name="seL4_RISCV_PageTable" manual_name="Page Table" cap_description="Capability to the page table to invoke.">
+        <method id="RISCVPageTableMap" name="Map" manual_label="pagetable_map">
+            <brief>
+                Map a page table at a specific virtual address.
+            </brief>
+            <description>
+                Starting from the VSpace, map the page table object at any unpopulated level for the provided virtual address. If all paging structures and mappings are present for this virtual address, return an seL4_DeleteFirst error.
+            </description>
+            <param dir="in" name="vspace" type="seL4_RISCV_PageTable">
+                <description>VSpace to map the lower-level page table into.</description>
+            </param>
+            <param dir="in" name="vaddr" type="seL4_Word">
+                <description>Virtual address at which to map the page table.</description>
+            </param>
+            <param dir="in" name="attr" type="seL4_RISCV_VMAttributes">
+            <description>
+                VM Attributes for the mapping. <docref>Possible values for this type are given
+                in <autoref label="ch:vspace"/>.</docref>
+            </description>
+            </param>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    A page is mapped in <texttt text="vspace"/> at <texttt text="vaddr"/>.
+                    Or, all required page tables are already mapped in <texttt text="vspace"/> at <texttt text="vaddr"/>.
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="vspace"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="vaddr"/> is in the kernel virtual address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="vspace"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="vspace"/> is not assigned to an ASID pool.
+                    Or, <texttt text="_service"/> is already mapped in a VSpace.
+                </description>
+            </error>
+        </method>
+        <method id="RISCVPageTableUnmap" name="Unmap" manual_label="pagetable_unmap">
+            <brief>
+                Unmap a page table.
+            </brief>
+            <description>
+                <docref>See <autoref label="ch:vspace"/></docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    The <texttt text="_service"/> is the root of a VSpace.
+                    Or, a copy of the <texttt text="_service"/> capability exists.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_RISCV_Page" manual_name="Page" cap_description="Capability to the page to invoke.">
+        <method id="RISCVPageMap" name="Map">
+            <brief>
+                Map a page into a page table.
+            </brief>
+            <description>
+                Takes a VSpace, or top-level <texttt text="Page Table"/>,
+                capability as an argument and installs a reference
+                to the given <texttt text="Page"/> in the page table slot corresponding to the given address. If a page is already mapped at the same virtual address, update the mapping attributes.
+                If the required paging structures are not present
+                this operation will fail, returning a seL4_FailedLookup error.
+            </description>
+            <param dir="in" name="vspace" type="seL4_RISCV_PageTable">
+                <description>VSpace to map the page into.</description>
+            </param>
+            <param dir="in" name="vaddr" type="seL4_Word">
+                <description>Virtual address at which to map the page.</description>
+            </param>
+            <param dir="in" name="rights" type="seL4_CapRights_t">
+                <description>
+                    Rights for the mapping. <docref>Possible values for this type are given in <autoref label="sec:cap_rights"/>.</docref>
+                </description>
+            </param>
+            <param dir="in" name="attr" type="seL4_RISCV_VMAttributes">
+            <description>
+                VM Attributes for the mapping. <docref>Possible values for this type are given
+                in <autoref label="ch:vspace"/>.</docref>
+            </description>
+            </param>
+            <error name="seL4_AlignmentError">
+                <description>
+                    The <texttt text="vaddr"/> is not aligned to the page size of <texttt text="_service"/>.
+                </description>
+            </error>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    A mapping already exists in <texttt text="vspace"/> at <texttt text="vaddr"/>.
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="vspace"/> does not have a paging structure at the required level mapped at <texttt text="vaddr"/>.
+                    Or, <texttt text="vspace"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="_service"/> is already mapped in <texttt text="vspace"/> at a different virtual address.
+                    Or, <texttt text="vaddr"/> is in the kernel virtual address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="vspace"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="vspace"/> is not the root of a VSpace.
+                    Or, <texttt text="vspace"/> is not assigned to an ASID pool.
+                    Or, <texttt text="_service"/> is already mapped in a different VSpace.
+                </description>
+            </error>
+        </method>
+        <method id="RISCVPageUnmap" name="Unmap">
+            <brief>
+               Unmap a page.
+            </brief>
+            <description>
+                Removes an existing mapping.
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="RISCVPageGetAddress" name="GetAddress" manual_name="Get Address">
+            <brief>
+                Get the physical address of a page.
+            </brief>
+            <description>
+                <docref>See <autoref label="ch:vspace"/>.</docref>
+            </description>
+            <return>
+                A <texttt text='seL4_RISCV_Page_GetAddress_t'/> struct that contains a
+                <texttt text='seL4_Word paddr'/>, which holds the physical address of the page,
+                and <texttt text='int error'/>. <docref>See <autoref label='sec:errors'/> for a description
+                of the message register and tag contents upon error.</docref>
+            </return>
+            <param dir="out" name="paddr" type="seL4_Word"/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_RISCV_ASIDControl" manual_name="ASID Control"
+        cap_description="The master ASIDControl capability to invoke.">
+        <method id="RISCVASIDControlMakePool" name="MakePool" manual_name="Make Pool">
+           <brief>
+                Create an ASID Pool.
+            </brief>
+            <description>
+                Together with a capability to <texttt text="Untyped Memory"/>, which is passed as an argument,
+                create an <texttt text="ASID Pool"/>. The untyped capability must represent a
+                4K memory object. This will create an ASID pool with enough space for 1024 VSpaces.
+            </description>
+            <param dir="in" name="untyped" type="seL4_Untyped"
+            description="Capability to an untyped memory object that will become the pool. Must be 4K bytes."/>
+            <param dir="in" name="root" type="seL4_CNode"
+            description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth of 32."/>
+            <param dir="in" name="index" type="seL4_Word"
+            description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth of 32."/>
+            <param dir="in" name="depth" type="seL4_Uint8"
+            description="Number of bits of index to resolve to find the destination slot."/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    The destination slot contains a capability.
+                    Or, there are no more ASID pools available.
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="index"/> or <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="root"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="untyped"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="untyped"/> is not the exact size of an ASID pool object.
+                    Or, <texttt text="untyped"/> is a device untyped <docref>(see <autoref label="sec:kernmemalloc"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    The <texttt text="untyped"/> has been used to retype an object.
+                    Or, a copy of the <texttt text="untyped"/> capability exists.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_RISCV_ASIDPool" manual_name="ASID Pool"
+        cap_description="The ASID Pool capability to invoke, which must be to an ASID pool that is not full.">
+        <method id="RISCVASIDPoolAssign" name="Assign">
+            <brief>
+                Assign an ASID Pool.
+            </brief>
+            <description>
+                Assigns an ASID to the VSpace passed in as an argument.
+            </description>
+            <param dir="in" name="vspace" type="seL4_CPtr">
+            <description>
+                The top-level <texttt text="PageTable" /> that is being assigned to an ASID pool. Must not already be assigned
+                    to an ASID pool.
+            </description>
+            </param>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    There are no more ASIDs available in <texttt text="_service"/>.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="vspace"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="vspace"/> is already assigned to an ASID pool.
+                    Or, <texttt text="vspace"/> is mapped in a VSpace.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_IRQControl" manual_name="IRQ Control" cap_description="An IRQControl capability. This gives you the authority to make this call.">
+
+       <method id="RISCVIRQIssueIRQHandlerTrigger" name="GetTrigger" manual_name="Get IRQ Handler with Trigger Type"
+           manual_label="irq_controlgettrigger">
+            <brief>
+                Create an IRQ handler capability and specify the trigger method (edge or level).
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:interrupts"/>.</docref>
+            </description>
+            <param dir="in" name="irq" type="seL4_Word" description="The IRQ that you want this capability to handle."/>
+
+            <param dir="in" name="trigger" type="seL4_Word" description="Indicates whether this IRQ is edge (1) or level (0) triggered."/>
+            <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
+            <error name="seL4_DeleteFirst">
+                <description>
+                    The destination slot contains a capability.
+                </description>
+            </error>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="index"/> or <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="root"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, the platform does not support setting the IRQ trigger.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="irq"/> is invalid.
+                    Or, <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    An IRQ handler capability for <texttt text="irq"/> has already been created.
+                </description>
+            </error>
+        </method>
+
+    </interface>
+
+</api>

--- a/libsel4/arch_include/riscv/sel4/arch/objecttype.h
+++ b/libsel4/arch_include/riscv/sel4/arch/objecttype.h
@@ -16,4 +16,4 @@ typedef enum _object {
     seL4_ObjectTypeCount
 } seL4_ArchObjectType;
 
-typedef seL4_Word object_t; 
+typedef seL4_Word object_t;

--- a/libsel4/include/interfaces/object-api.xml
+++ b/libsel4/include/interfaces/object-api.xml
@@ -1,0 +1,1525 @@
+<?xml version="1.0" ?>
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: BSD-2-Clause
+-->
+
+<api name="ObjectApi">
+
+    <interface name="seL4_Untyped" manual_name="Untyped" cap_description="CPtr to an untyped object.">
+
+        <method id="UntypedRetype" name="Retype" manual_label="untyped_retype">
+            <brief>
+                Retype an untyped object
+            </brief>
+            <description>
+                Given a capability, <texttt text="_service"/>, to an untyped object,
+                creates <texttt text="num_objects"/> of the requested type. Creates
+                <texttt text="num_objects"/> capabilities to the new objects starting
+                at <texttt text="node_offset"/> in the CNode specified by
+                <texttt text="root"/>, <texttt text="node_index"/>, and
+                <texttt text="node_depth"/>.
+
+                For variable-sized
+                kernel objects, the <texttt text="size_bits"/> argument is used to
+                determine the size of objects to create. The relationship between
+                <texttt text="size_bits"/> and object size depends on the type of object
+                being created. <docref>See <autoref label="sec:object_sizes"/> for more information
+                about object sizes.</docref>
+
+                <docref>See <autoref label="sec:kernmemalloc"/> for more information about how untyped
+                memory is retyped.</docref>
+
+                <docref>See <autoref label="sec:caps_to_new_objects"/> for more information about the
+                placement of capabilities to created objects.</docref>
+            </description>
+            <param dir="in" name="type" type="seL4_Word"
+                description="The seL4 object type that we are retyping to."/>
+            <param dir="in" name="size_bits" type="seL4_Word"
+                description="Used to determine the size of variable-sized objects."/>
+            <param dir="in" name="root" type="seL4_CNode"
+                description="CPtr to the CNode at the root of the destination CSpace."/>
+            <param dir="in" name="node_index" type="seL4_Word"
+                description="CPtr to the destination CNode. Resolved relative to the root parameter."/>
+            <param dir="in" name="node_depth" type="seL4_Word"
+                description="Number of bits of node_index to translate when addressing the destination CNode."/>
+            <param dir="in" name="node_offset" type="seL4_Word"
+                description="Number of slots into the node at which capabilities start being placed."/>
+            <param dir="in" name="num_objects" type="seL4_Word"
+                description="Number of capabilities to create."/>
+            <error name="seL4_DeleteFirst" description="A capability exists in the destination window of the CNode."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="root"/>, <texttt text="node_index"/>, or <texttt text="node_depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="size_bits"/> is too big or too small for the requested object type.
+                    Or, <texttt text="type"/> cannot be created from a device untyped <docref>(see <autoref label="sec:kernmemalloc"/>)</docref>.
+                    Or, the requested object <texttt text="type"/> does not exist.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_NotEnoughMemory" description="The total size of the new objects exceeds the space available."/>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="num_objects"/> do not fit in the destination CNode at <texttt text="node_offset"/>.
+                    Or, <texttt text="num_objects"/> is greater than <texttt text="CONFIG_RETYPE_FAN_OUT_LIMIT"/>.
+                    Or, <texttt text="size_bits"/> is too large.
+                </description>
+            </error>
+        </method>
+
+    </interface>
+
+    <interface name="seL4_TCB" manual_name="TCB" cap_description="Capability to the TCB which is being operated on.">
+
+        <method id="TCBReadRegisters" name="ReadRegisters" manual_name="Read Registers" manual_label="tcb_readregisters">
+            <brief>
+                Read a thread's registers into the first <texttt text="count"/> fields of a given
+                seL4_UserContext
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:read_write_registers"/></docref>
+            </description>
+            <param dir="in" name="suspend_source" type="seL4_Bool"
+                description="The invocation should also suspend the source thread."/>
+            <param dir="in" name="arch_flags" type="seL4_Uint8"
+                description="Architecture dependent flags. These have no meaning on x86, ARM, and RISC-V."/>
+            <param dir="in" name="count" type="seL4_Word" description="The number of registers to read."/>
+            <param dir="out" name="regs" type="seL4_UserContext"
+                description="The structure to read the registers into."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is the current thread's TCB.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="count"/> requested too few or too many registers.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBWriteRegisters" name="WriteRegisters" manual_name="Write Registers" manual_label="tcb_writeregisters">
+            <brief>
+                Set a thread's registers to the first <texttt text="count"/> fields of a given seL4_UserContext
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:read_write_registers"/></docref>
+            </description>
+            <param dir="in" name="resume_target" type="seL4_Bool"
+                description="The invocation should also resume the destination thread."/>
+            <param dir="in" name="arch_flags" type="seL4_Uint8"
+                description="Architecture dependent flags. These have no meaning on x86, ARM, and RISC-V."/>
+            <param dir="in" name="count" type="seL4_Word"
+                description="The number of registers to be set."/>
+            <param dir="in" name="regs" type="seL4_UserContext"
+                description="Data structure containing the new register values."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is the current thread's TCB.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBCopyRegisters" name="CopyRegisters" manual_name="Copy Registers" manual_label="tcb_copyregisters">
+            <brief>
+                Copy the registers from one thread to another
+            </brief>
+            <description>
+                In the context of this function, frame registers are those that are read, modified or preserved by a
+                system call and integer registers are those that are not. Refer to the seL4 userland library source for specifics.
+                <docref><autoref label="sec:thread_deactivation"/></docref>
+            </description>
+            <cap_param append_description=" This is the destination TCB."/>
+            <param dir="in" name="source" type="seL4_TCB" description="Cap to the source TCB."/>
+            <param dir="in" name="suspend_source" type="seL4_Bool"
+                description="The invocation should also suspend the source thread."/>
+            <param dir="in" name="resume_target" type="seL4_Bool"
+                description="The invocation should also resume the destination thread."/>
+            <param dir="in" name="transfer_frame" type="seL4_Bool"
+                description="Frame registers should be transferred."/>
+            <param dir="in" name="transfer_integer" type="seL4_Bool"
+                description="Integer registers should be transferred."/>
+            <param dir="in" name="arch_flags" type="seL4_Uint8"
+                description="Architecture dependent flags. These have no meaning on x86, ARM, and RISC-V."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="source"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBConfigure" name="Configure" manual_label="tcb_configure">
+            <condition><not><config var="CONFIG_KERNEL_MCS"/></not></condition>
+            <brief>
+                Set the parameters of a TCB
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:threads"/></docref>
+            </description>
+            <param dir="in" name="fault_ep" type="seL4_Word"
+                description="CPtr to the endpoint which receives IPCs when this thread faults. This capability is in the CSpace of the thread being configured."/>
+            <param dir="in" name="cspace_root" type="seL4_CNode"
+                description="The new CSpace root."/>
+            <param dir="in" name="cspace_root_data" type="seL4_Word"
+                description="Optionally set the guard and guard size of the new root CNode. If set to zero, this parameter has no effect."/>
+            <param dir="in" name="vspace_root" type="seL4_CPtr"
+                description="The new VSpace root."/>
+            <param dir="in" name="vspace_root_data" type="seL4_Word"
+                description="Has no effect on x86 or ARM processors."/>
+            <param dir="in" name="buffer" type="seL4_Word"
+                description="Location of the thread's IPC buffer. Must be 512-byte aligned. The IPC buffer may not cross a page boundary."/>
+            <param dir="in" name="bufferFrame" type="seL4_CPtr"
+                description="Capability to a page containing the thread's IPC buffer."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/>, <texttt text="bufferFrame"/>, <texttt text="cspace_root"/>, or <texttt text="vspace_root"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="vspace_root"/> is not assigned to an ASID pool.
+                    Or, <texttt text="cspace_root_data"/> is invalid.
+                    Or, <texttt text="buffer"/> is not aligned.
+                    Or, <texttt text="bufferFrame"/> is retyped from a device untyped <docref>(see <autoref label="sec:kernmemalloc"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    The <texttt text="bufferFrame"/>, <texttt text="cspace_root"/>, or <texttt text="vspace_root"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="TCBConfigure" name="Configure" manual_name="Configure (MCS)" manual_label="tcb_configure_mcs">
+            <condition><config var="CONFIG_KERNEL_MCS"/></condition>
+            <brief>
+                Set the parameters of a TCB
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:threads"/></docref>
+            </description>
+            <param dir="in" name="cspace_root" type="seL4_CNode"
+                description="The new CSpace root."/>
+            <param dir="in" name="cspace_root_data" type="seL4_Word"
+                description="Optionally set the guard and guard size of the new root CNode. If set to zero, this parameter has no effect."/>
+            <param dir="in" name="vspace_root" type="seL4_CPtr"
+                description="The new VSpace root."/>
+            <param dir="in" name="vspace_root_data" type="seL4_Word"
+                description="Has no effect on x86 or ARM processors."/>
+            <param dir="in" name="buffer" type="seL4_Word"
+                description="Location of the thread's IPC buffer. Must be 512-byte aligned. The IPC buffer may not cross a page boundary."/>
+            <param dir="in" name="bufferFrame" type="seL4_CPtr"
+                description="Capability to a page containing the thread's IPC buffer."/>
+            <error name="seL4_AlignmentError">
+                <description>
+                    The <texttt text="buffer"/> is not aligned.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/>, <texttt text="bufferFrame"/>, <texttt text="cspace_root"/>, or <texttt text="vspace_root"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="vspace_root"/> is not assigned to an ASID pool.
+                    Or, <texttt text="cspace_root_data"/> is invalid.
+                    Or, <texttt text="bufferFrame"/> is retyped from a device untyped <docref>(see <autoref label="sec:kernmemalloc"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    The <texttt text="bufferFrame"/>, <texttt text="cspace_root"/>, or <texttt text="vspace_root"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBSetPriority" name="SetPriority" manual_name="Set Priority" manual_label="tcb_setpriority">
+            <brief>
+                Change a thread's priority
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:sched"/></docref>
+            </description>
+            <param dir="in" name="authority" type="seL4_TCB"
+                description="Capability to the TCB to use the MCP from when setting the priority."/>
+            <param dir="in" name="priority" type="seL4_Word"
+                description="The thread's new priority."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="authority"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="priority"/> is greater than the maximum controlled priority of <texttt text="authority"/>.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBSetMCPriority" name="SetMCPriority" manual_name="Set Maximum Controlled Priority" manual_label="tcb_setmcpriority">
+            <brief>
+                Change a thread's maximum controlled priority
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:sched"/></docref>
+            </description>
+            <param dir="in" name="authority" type="seL4_TCB"
+                description="Capability to the TCB to use the MCP from when setting the MCP."/>
+            <param dir="in" name="mcp" type="seL4_Word"
+                description="The thread's new maximum controlled priority."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="authority"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="mcp"/> is greater than the maximum controlled priority of <texttt text="authority"/>.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBSetSchedParams" name="SetSchedParams" manual_name="Set Sched Params" manual_label="tcb_setschedparams">
+            <condition><not><config var="CONFIG_KERNEL_MCS"/></not></condition>
+            <brief>
+                Change a thread's priority and maximum controlled priority.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:sched"/></docref>
+            </description>
+            <param dir="in" name="authority" type="seL4_TCB"
+                description="Capability to the TCB to use the MCP from when setting the priority and MCP."/>
+            <param dir="in" name="mcp" type="seL4_Word"
+                description="The thread's new maximum controlled priority."/>
+            <param dir="in" name="priority" type="seL4_Word"
+                description="The thread's new priority."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="authority"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="mcp"/> is greater than the maximum controlled priority of <texttt text="authority"/>.
+                    Or, <texttt text="priority"/> is greater than the maximum controlled priority of <texttt text="authority"/>.
+                </description>
+            </error>
+        </method>
+        <method id="TCBSetSchedParams" name="SetSchedParams" manual_name="Set Sched Params (MCS)" manual_label="tcb_setschedparams_mcs">
+            <condition><config var="CONFIG_KERNEL_MCS"/></condition>
+            <brief>
+                Change a thread's priority, maximum controlled priority, scheduling context
+                and fault handler.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:sched"/></docref>
+            </description>
+            <param dir="in" name="authority" type="seL4_TCB"
+                description="Capability to the TCB to use the MCP from when setting the priority and MCP."/>
+            <param dir="in" name="mcp" type="seL4_Word"
+                description="The thread's new maximum controlled priority."/>
+            <param dir="in" name="priority" type="seL4_Word"
+                description="The thread's new priority."/>
+            <param dir="in" name="sched_context" type="seL4_CPtr"
+                description="Capability to the scheduling context that the TCB should run on. If the scheduling context is already bound to a notification or TCB that is not this TCB this operation will fail. Similarly, if this TCB is already bound to a scheduling context that is not this scheduling context, this will also fail."/>
+            <param dir="in" name="fault_ep" type="seL4_CPtr"
+                description="CPtr to the endpoint which receives IPCs when this thread faults."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> or <texttt text="sched_context"/> is already bound.
+                    Or, <texttt text="_service"/> is the current thread's TCB.
+                    Or, <texttt text="_service"/> is a TCB in the blocked state and <texttt text="sched_context"/> is not schedulable.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/>, <texttt text="authority"/>, <texttt text="sched_context"/>, or <texttt text="fault_ep"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="fault_ep"/> does not have both Write rights and either Grant or GrantReply rights to the Endpoint <docref>(see <autoref label="sec:cap_rights"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="mcp"/> is greater than the maximum controlled priority of <texttt text="authority"/>.
+                    Or, <texttt text="priority"/> is greater than the maximum controlled priority of <texttt text="authority"/>.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBSetTimeoutEndpoint" name="SetTimeoutEndpoint" manual_name="Set Timeout Endpoint" manual_label="tcb_settimeoutendpoint">
+            <condition><config var="CONFIG_KERNEL_MCS"/></condition>
+            <brief>
+                Set a thread's timeout endpoint.
+            </brief>
+            <description>
+                Timeout exception messages will be delivered to this endpoint if it is not a null capability.
+            </description>
+            <param dir="in" name="timeout_fault_ep" type="seL4_CPtr"
+                description="CPtr to the endpoint which receives IPCs when this thread triggers timeout faults. Can be null."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="timeout_fault_ep"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="timeout_fault_ep"/> does not have both Write rights and either Grant or GrantReply rights to the Endpoint <docref>(see <autoref label="sec:cap_rights"/>)</docref>.
+                </description>
+            </error>
+        </method>
+        <method id="TCBSetIPCBuffer" name="SetIPCBuffer" manual_name="Set IPC Buffer" manual_label="tcb_setipcbuffer">
+            <brief>
+                Set a thread's IPC buffer
+            </brief>
+            <description>
+                See Sections <shortref sec="threads"/> and <shortref sec="messageinfo"/>
+            </description>
+            <param dir="in" name="buffer" type="seL4_Word"
+                description="Location of the thread's IPC buffer. Must be 512-byte aligned. The IPC buffer may not cross a page boundary."/>
+            <param dir="in" name="bufferFrame" type="seL4_CPtr"
+                description="Capability to a page containing the thread's IPC buffer."/>
+            <error name="seL4_AlignmentError">
+                <description>
+                    The <texttt text="buffer"/> is not aligned.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="bufferFrame"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="bufferFrame"/> is retyped from a device untyped <docref>(see <autoref label="sec:kernmemalloc"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    The <texttt text="bufferFrame"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBSetSpace" name="SetSpace" manual_name="Set Space" manual_label="tcb_setspace">
+            <condition><not><config var="CONFIG_KERNEL_MCS"/></not></condition>
+            <brief>
+                Set the fault endpoint, CSpace and VSpace of a thread
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:threads"/></docref>
+            </description>
+            <param dir="in" name="fault_ep" type="seL4_Word"
+                description="CPtr to the endpoint which receives IPCs when this thread faults. This capability is in the CSpace of the thread being configured."/>
+            <param dir="in" name="cspace_root" type="seL4_CNode"
+                description="The new CSpace root."/>
+            <param dir="in" name="cspace_root_data" type="seL4_Word"
+                description="Optionally set the guard and guard size of the new root CNode. If set to zero, this parameter has no effect."/>
+            <param dir="in" name="vspace_root" type="seL4_CPtr"
+                description="The new VSpace root."/>
+            <param dir="in" name="vspace_root_data" type="seL4_Word"
+                description="Has no effect on x86 or ARM processors."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/>, <texttt text="cspace_root"/>, or <texttt text="vspace_root"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="vspace_root"/> is not assigned to an ASID pool.
+                    Or, <texttt text="cspace_root_data"/> is invalid.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    The <texttt text="cspace_root"/> or <texttt text="vspace_root"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBSetSpace" name="SetSpace" manual_name="Set Space (MCS)" manual_label="tcb_setspace_mcs">
+            <condition><config var="CONFIG_KERNEL_MCS"/></condition>
+            <brief>
+                Set the fault endpoint, CSpace and VSpace of a thread
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:threads"/></docref>
+            </description>
+            <param dir="in" name="fault_ep" type="seL4_CPtr"
+                description="CPtr to the endpoint which receives IPCs when this thread faults. On MCS this cap gets copied into the TCB."/>
+            <param dir="in" name="cspace_root" type="seL4_CNode"
+                description="The new CSpace root."/>
+            <param dir="in" name="cspace_root_data" type="seL4_Word"
+                description="Optionally set the guard and guard size of the new root CNode. If set to zero, this parameter has no effect."/>
+            <param dir="in" name="vspace_root" type="seL4_CPtr"
+                description="The new VSpace root."/>
+            <param dir="in" name="vspace_root_data" type="seL4_Word"
+                description="Has no effect on x86 or ARM processors."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/>, <texttt text="cspace_root"/>, or <texttt text="vspace_root"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="vspace_root"/> is not assigned to an ASID pool.
+                    Or, <texttt text="cspace_root_data"/> is invalid.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="fault_ep"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="fault_ep"/> does not have both Write rights and either Grant or GrantReply rights to the Endpoint <docref>(see <autoref label="sec:cap_rights"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    The <texttt text="cspace_root"/> or <texttt text="vspace_root"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBSuspend" name="Suspend" manual_label="tcb_suspend">
+            <brief>
+                Suspend a thread
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:thread_deactivation"/></docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBResume" name="Resume" manual_label="tcb_resume">
+            <brief>
+                Resume a thread
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:thread_deactivation"/></docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBBindNotification" name="BindNotification" manual_name="Bind Notification" manual_label="tcb_bindnotification">
+            <brief>
+                Binds a notification object to a <obj name="TCB"/>
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:notification-binding"/></docref>
+            </description>
+            <param dir="in" name="notification" type="seL4_CPtr" description="Notification to bind."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="notification"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> or <texttt text="notification"/> is already bound.
+                    Or, <texttt text="notification"/> does not have Read rights to the Notification <docref>(see <autoref label="sec:cap_rights"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBUnbindNotification" name="UnbindNotification" manual_name="Unbind Notification" manual_label="tcb_unbindnotification">
+            <brief>
+                Unbinds any notification object from a <obj name="TCB"/>
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:notification-binding"/></docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not bound to a notification.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBSetAffinity" name="SetAffinity" manual_name="Set CPU Affinity" manual_label="tcb_setaffinity">
+            <condition>
+                <and>
+                    <not><config var="CONFIG_KERNEL_MCS"/></not>
+                    <config var="CONFIG_ENABLE_SMP_SUPPORT"/>
+                </and>
+            </condition>
+            <brief>
+                Change a thread's current CPU in multicore machine
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:thread_creation"/></docref>
+            </description>
+            <param dir="in" name="affinity" type="seL4_Word"
+                description="The thread's new CPU to run."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="affinity"/> is not a valid CPU number.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBSetBreakpoint" name="SetBreakpoint" manual_name="Set Breakpoint" manual_label="tcb_setbreakpoint">
+            <condition><config var="CONFIG_HARDWARE_DEBUG_API"/></condition>
+            <brief>
+                Set or modify a thread's breakpoints or watchpoints. Calls to this function
+                overwrite previous configurations for the target breakpoint. Do not use this
+                with seL4_SingleStep: the API will reject the call and return an error.
+                Instead, use seL4_TCB_ConfigureSingleStepping to configure single-stepping.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:debug_exceptions"/></docref>
+            </description>
+            <param dir="in" name="bp_num" type="seL4_Uint16"
+                description="The API-ID of a target breakpoint. This ID will be a positive integer, with values ranging from 0 to seL4_NumHWBreakpoints - 1."/>
+            <param dir="in" name="vaddr" type="seL4_Word"
+                description="A virtual address which forms part of the match conditions for the triggering of the breakpoint."/>
+            <param dir="in" name="type" type="seL4_Word"
+                description="One of: seL4_InstructionBreakpoint, which specifies that the breakpoint should occur on instruction execution at the specified vaddr or seL4_DataBreakpoint, which states that the breakpoint should occur on data access at the specified vaddr."/>
+            <param dir="in" name="size" type="seL4_Word"
+                description="A positive integer indicating the trigger-span of the watchpoint. Must be zero when 'type' is seL4_InstructionBreakpoint."/>
+            <param dir="in" name="rw" type="seL4_Word"
+                description="One of seL4_BreakOnRead, meaning the breakpoint will only be triggered on read-access; seL4_BreakOnWrite meaning the breakpoint will only be triggered on write-access, and seL4_BreakOnReadWrite meaning the breakpoint will be triggered on any access."/>
+            <error name="seL4_AlignmentError">
+                <description>
+                    The <texttt text="vaddr"/> is not aligned to <texttt text="size"/> bytes.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="bp_num"/>, <texttt text="size"/>, or <texttt text="rw"/> is not valid for the given <texttt text="type"/>.
+                    Or, argument values are inappropriate for the target architecture.
+                    Or, <texttt text="vaddr"/> is in the kernel virtual address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The argument values are inappropriate for the target architecture.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBGetBreakpoint" name="GetBreakpoint" manual_name="Get Breakpoint" manual_label="tcb_getbreakpoint">
+            <condition><config var="CONFIG_HARDWARE_DEBUG_API"/></condition>
+            <brief>
+                Read a breakpoint or watchpoint's current configuration.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:debug_exceptions"/></docref>
+            </description>
+            <return>
+                A <texttt text="seL4_TCB_GetBreakpoint_t"/>: Struct that contains
+                <texttt text="seL4_Error error"/>, an seL4 API error value,
+                <texttt text="seL4_Word vaddr"/>, the virtual address at which the breakpoint will currently
+                be triggered;
+                <texttt text="seL4_Word type"/>, the type of operation which will currently trigger the
+                breakpoint, whether instruction execution, or data access;
+                <texttt text="seL4_Word size"/>, integer value for the span-size of the breakpoint.
+                Usually a power of two (1, 2, 4, etc.);
+                <texttt text="seL4_Word rw"/>, the access direction that will currently trigger the breakpoint,
+                whether read, write, or both and
+                <texttt text="seL4_Bool is_enabled"/>, which indicates whether or not the breakpoint
+                will currently be triggered if the match conditions are met.
+            </return>
+            <param dir="in" name="bp_num" type="seL4_Uint16"
+                description="The API-ID of a target breakpoint. This ID will be a positive integer, with values ranging from 0 to seL4_NumHWBreakpoints - 1."/>
+            <param dir="out" name="vaddr" type="seL4_Word"/>
+            <param dir="out" name="type" type="seL4_Word"/>
+            <param dir="out" name="size" type="seL4_Word"/>
+            <param dir="out" name="rw" type="seL4_Word"/>
+            <param dir="out" name="is_enabled" type="seL4_Bool"/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The argument values are inappropriate for the target architecture.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBUnsetBreakpoint" name="UnsetBreakpoint" manual_name="Unset Breakpoint" manual_label="tcb_unsetbreakpoint">
+            <condition><config var="CONFIG_HARDWARE_DEBUG_API"/></condition>
+            <brief>
+                Disables a hardware breakpoint or watchpoint. The caller should assume that
+                the underlying configuration of the hardware registers has also been cleared.
+                Do not use this to clear single-stepping: the API will reject the call and
+                return an error. Instead, use seL4_TCB_ConfigureSingleStepping to disable
+                single-stepping.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:debug_exceptions"/></docref>
+            </description>
+            <param dir="in" name="bp_num" type="seL4_Uint16"
+                description="The API-ID of a target breakpoint. This ID will be a positive integer, with values ranging from 0 to seL4_NumHWBreakpoints - 1."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, the argument values are inappropriate for the target architecture.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The argument values are inappropriate for the target architecture.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBConfigureSingleStepping" name="ConfigureSingleStepping"
+            manual_name="Configure Single Stepping" manual_label="tcb_configuresinglestepping">
+            <condition><config var="CONFIG_HARDWARE_DEBUG_API"/></condition>
+            <brief>
+                Set or modify single stepping options for the target TCB. Subsequent calls to this
+                function overwrite previous configuration. Depending on your processor architecture,
+                this may or may not require the consumption of a hardware register.
+            </brief>
+            <description>
+                <docref>See Sections <shortref sec="single_stepping_debug_exception"/> and <shortref sec="debug_exceptions"/></docref>
+            </description>
+            <return>
+                A <texttt text="seL4_TCB_ConfigureSingleStepping_t"/>: Struct that contains
+                <texttt text="seL4_Error error"/>, an seL4 API error value,
+                <texttt text="seL4_Bool bp_was_consumed"/>, a boolean which indicates whether or not the <texttt text="bp_num"/>
+                breakpoint ID that was passed to the function, was consumed in the setup of the single-stepping
+                functionality: if this is <texttt text="true"/>, the caller should not attempt to re-use <texttt text="bp_num"/>
+                until it has disabled the single-stepping functionality via a subsequent call to
+                seL4_TCB_ConfigureSingleStepping with an <texttt text="num_instructions"/> argument of 0.
+            </return>
+            <param dir="in" name="bp_num" type="seL4_Uint16"
+                description="The API-ID of a target breakpoint. This ID will be a positive integer, with values ranging from 0 to seL4_NumHWBreakpoints - 1."/>
+            <param dir="in" name="num_instructions" type="seL4_Word"
+                description="Number of instructions to step over before delivering a fault to the target thread's fault endpoint. Setting this to 0 disables single-stepping."/>
+            <param dir="out" name="bp_was_consumed" type="seL4_Bool"/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, the argument values are inappropriate for the target architecture.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The argument values are inappropriate for the target architecture.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="TCBSetTLSBase" name="SetTLSBase" manual_name="Set TLS Base" manual_label="tcb_settlsbase">
+            <brief>
+                Set the TLS base of the target TCB.
+             </brief>
+             <description>
+                An invocation for setting the Thread Local Storage (TLS) base address. This ensures that across all platforms, the TLSBase register is viewed as being completely mutable, just like all of the general purpose registers, even on platforms where modification is a privileged operation.
+             </description>
+             <param dir="in" name="tls_base" type="seL4_Word"
+                description="The TLS base to set."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+         </method>
+
+    </interface>
+
+    <interface name="seL4_CNode" manual_name="CNode">
+        <method id="CNodeRevoke" name="Revoke" manual_label="cnode_revoke">
+            <brief>
+                Delete all child capabilities of a capability
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:cnode-ops"/>.</docref>
+            </description>
+            <cap_param append_description="CPtr to the CNode at the root of the CSpace where the capability will be found. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="index" type="seL4_Word" description="CPtr to the capability. Resolved from the root of the _service parameter."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the capability being operated on."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="index"/> or <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+        </method>
+
+        <method id="CNodeDelete" name="Delete" manual_label="cnode_delete">
+            <brief>
+                Delete a capability
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:cnode-ops"/>.</docref>
+            </description>
+            <cap_param append_description="CPtr to the CNode at the root of the CSpace where the capability will be found. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="index" type="seL4_Word" description="CPtr to the capability. Resolved from the root of the _service parameter."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the capability being operated on."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="index"/> or <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+        </method>
+
+        <method id="CNodeCancelBadgedSends" name="CancelBadgedSends" manual_name="Cancel Badged Sends" manual_label="cnode_cancelbadgedsends">
+            <brief>
+                The cancel badged sends method is intended to allow for the reuse of badges by an
+                authority. When used with a badged endpoint capability it
+                will cancel any outstanding send operations for that endpoint and badge.
+                This operation has no effect on un-badged or other objects.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:cnode-ops"/>.</docref>
+            </description>
+            <cap_param append_description="CPtr to the CNode at the root of the CSpace where the capability will be found. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="index" type="seL4_Word" description="CPtr to the capability. Resolved from the root of the _service parameter."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the capability being operated on."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="index"/> or <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, the capability does not have full rights to the Endpoint <docref>(see <autoref label="sec:cap_rights"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+        </method>
+
+        <method id="CNodeCopy" name="Copy" manual_label="cnode_copy">
+            <brief>
+                Copy a capability, setting its access rights whilst doing so
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:cnode-ops"/>.</docref>
+            </description>
+            <cap_param append_description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="dest_index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
+            <param dir="in" name="dest_depth" type="seL4_Uint8" description="Number of bits of dest_index to resolve to find the destination slot."/>
+            <param dir="in" name="src_root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the source CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="src_index" type="seL4_Word" description="CPtr to the source slot. Resolved from the root of the source CSpace."/>
+            <param dir="in" name="src_depth" type="seL4_Uint8" description="Number of bits of src_index to resolve to find the source slot."/>
+            <param dir="in" name="rights" type="seL4_CapRights_t">
+                <description>
+                    The rights inherited by the new capability.<docref> Possible values for this type are given in <autoref label="sec:cap_rights"/>  .</docref>
+                </description>
+            </param>
+            <error name="seL4_DeleteFirst" description="The destination slot contains a capability."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The index or depth of the source or destination is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="src_root"/> is a CPtr to a capability of the wrong type.
+                    Or, the source slot is empty.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, the source capability cannot be derived<docref> (see <autoref label="sec:cap_derivation"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="dest_depth"/> or <texttt text="src_depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    The source capability cannot be derived<docref> (see <autoref label="sec:cap_derivation"/>)</docref>.
+                </description>
+            </error>
+        </method>
+
+        <method id="CNodeMint" name="Mint" manual_label="cnode_mint">
+            <brief>
+                Copy a capability, setting its access rights and badge whilst doing so
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:cnode-ops"/>.</docref>
+            </description>
+            <cap_param append_description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="dest_index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
+            <param dir="in" name="dest_depth" type="seL4_Uint8" description="Number of bits of dest_index to resolve to find the destination slot."/>
+            <param dir="in" name="src_root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the source CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="src_index" type="seL4_Word" description="CPtr to the source slot. Resolved from the root of the source CSpace."/>
+            <param dir="in" name="src_depth" type="seL4_Uint8" description="Number of bits of src_index to resolve to find the source slot."/>
+            <param dir="in" name="rights" type="seL4_CapRights_t">
+                <description>
+                    The rights inherited by the new capability.<docref> Possible values for this type are given in <autoref label="sec:cap_rights"/>  .</docref>
+                </description>
+            </param>
+            <param dir="in" name="badge" type="seL4_Word" description="Badge or guard to be applied to the new capability. For badges on 32-bit platforms, the high 4 bits are ignored."/>
+            <error name="seL4_DeleteFirst" description="The destination slot contains a capability."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The index or depth of the source or destination is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="src_root"/> is a CPtr to a capability of the wrong type.
+                    Or, the source slot is empty.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, the source capability cannot be derived <docref>(see <autoref label="sec:cap_derivation"/>)</docref>.
+                    Or, the badge or guard value is invalid.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="dest_depth"/> or <texttt text="src_depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    The source capability cannot be derived <docref>(see <autoref label="sec:cap_derivation"/>)</docref>.
+                </description>
+            </error>
+        </method>
+
+        <method id="CNodeMove" name="Move" manual_label="cnode_move">
+            <brief>
+                Move a capability
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:cnode-ops"/>.</docref>
+            </description>
+            <cap_param append_description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="dest_index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
+            <param dir="in" name="dest_depth" type="seL4_Uint8" description="Number of bits of dest_index to resolve to find the destination slot."/>
+            <param dir="in" name="src_root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the source CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="src_index" type="seL4_Word" description="CPtr to the source slot. Resolved from the root of the source CSpace."/>
+            <param dir="in" name="src_depth" type="seL4_Uint8" description="Number of bits of src_index to resolve to find the source slot."/>
+            <error name="seL4_DeleteFirst" description="The destination slot contains a capability."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The index or depth of the source or destination is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="src_root"/> is a CPtr to a capability of the wrong type.
+                    Or, the source slot is empty.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="dest_depth"/> or <texttt text="src_depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+        </method>
+
+        <method id="CNodeMutate" name="Mutate" manual_label="cnode_mutate">
+            <brief>
+                Move a capability, setting its guard in the process. This
+                operation is mostly useful for setting the guard of a CNode
+                capability without losing revokability of that CNode capability.
+                All other uses can be replaced by a combination of Mint and
+                Delete.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:cnode-ops"/>.</docref>
+            </description>
+            <cap_param append_description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="dest_index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
+            <param dir="in" name="dest_depth" type="seL4_Uint8" description="Number of bits of dest_index to resolve to find the destination slot."/>
+            <param dir="in" name="src_root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the source CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="src_index" type="seL4_Word" description="CPtr to the source slot. Resolved from the root of the source CSpace."/>
+            <param dir="in" name="src_depth" type="seL4_Uint8" description="Number of bits of src_index to resolve to find the source slot."/>
+            <param dir="in" name="badge" type="seL4_Word" description="Guard to be applied to the new capability."/>
+            <error name="seL4_DeleteFirst" description="The destination slot contains a capability."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The index or depth of the source or destination is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="src_root"/> is a CPtr to a capability of the wrong type.
+                    Or, the source slot is empty.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, the guard value is invalid.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="dest_depth"/> or <texttt text="src_depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+        </method>
+
+        <method id="CNodeRotate" name="Rotate" manual_label="cnode_rotate">
+            <brief>
+                Given 3 capability slots - a destination, pivot and source - move the capability in the
+                pivot slot to the destination slot and the capability in the source slot to the pivot slot
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:cnode-ops"/>.</docref>
+            </description>
+            <cap_param append_description="CPtr to the CNode at the root of the CSpace where the destination slot will be found. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="dest_index" type="seL4_Word" description="CPtr to the destination slot. Resolved relative to _service. Must be empty unless it refers to the same slot as the source slot."/>
+            <param dir="in" name="dest_depth" type="seL4_Uint8" description="Depth to resolve dest_index to."/>
+            <param dir="in" name="dest_badge" type="seL4_Word" description="The new capdata for the capability that ends up in the destination slot."/>
+            <param dir="in" name="pivot_root" type="seL4_CNode" description="CPtr to the CNode at the root of the CSpace where the pivot slot will be found. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="pivot_index" type="seL4_Word" description="CPtr to the pivot slot. Resolved relative to pivot_root. The resolved slot must not refer to the source or destination slots."/>
+            <param dir="in" name="pivot_depth" type="seL4_Uint8" description="Depth to resolve pivot_index to."/>
+            <param dir="in" name="pivot_badge" type="seL4_Word" description="The new capdata for the capability that ends up in the pivot slot."/>
+            <param dir="in" name="src_root" type="seL4_CNode" description="CPtr to the CNode at the root of the CSpace where the source slot will be found. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="src_index" type="seL4_Word" description="CPtr to the source slot. Resolved relative to src_root."/>
+            <param dir="in" name="src_depth" type="seL4_Uint8" description="Depth to resolve src_index to."/>
+            <error name="seL4_DeleteFirst" description="If the destination is not the same slot as the source and the destination slot contains a capability."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The index or depth of the source, destination, or pivot is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                    Or, <texttt text="src_root"/> or <texttt text="pivot_root"/> is a CPtr to a capability of the wrong type.
+                    Or, the source or pivot slot is empty.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, the pivot is the same slot as the source or destination.
+                    Or, the guard value on the destination or pivot is invalid.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="dest_depth"/>, <texttt text="src_depth"/>, or <texttt text="pivot_depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+        </method>
+
+        <method id="CNodeSaveCaller" name="SaveCaller" manual_name="Save Caller" manual_label="cnode_savecaller">
+            <condition><not><config var="CONFIG_KERNEL_MCS"/></not></condition>
+            <brief>
+                Save the reply capability from the last time the thread was called in the given CSpace so that it can be invoked later
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:cnode-ops"/>.</docref>
+            </description>
+            <cap_param append_description="CPtr to the CNode at the root of the CSpace where the capability is to be saved. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="index" type="seL4_Word" description="CPtr to the slot in which to save the capability. Resolved from the root of the _service parameter."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the slot being targeted."/>
+            <error name="seL4_DeleteFirst" description="The destination slot contains a capability."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="index"/> or <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+        </method>
+
+    </interface>
+
+    <interface name="seL4_IRQControl" manual_name="IRQ Control" cap_description="An IRQControl capability. This gives you the authority to make this call.">
+
+        <method id="IRQIssueIRQHandler" name="Get" manual_name="Get IRQ Handler" manual_label="irq_controlget">
+            <brief>
+                Create an IRQ handler capability
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:interrupts"/>.</docref>
+            </description>
+            <param dir="in" name="irq" type="seL4_Word" description="The IRQ that you want this capability to handle."/>
+            <param dir="in" name="root" type="seL4_CNode" description="CPtr to the CNode that forms the root of the destination CSpace. Must be at a depth equivalent to the wordsize."/>
+            <param dir="in" name="index" type="seL4_Word" description="CPtr to the destination slot. Resolved from the root of the destination CSpace."/>
+            <param dir="in" name="depth" type="seL4_Uint8" description="Number of bits of index to resolve to find the destination slot."/>
+            <error name="seL4_DeleteFirst" description="The destination slot contains a capability."/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="root"/>, <texttt text="index"/>, or <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, on x86, an IOAPIC is being used.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="irq"/> is invalid for the target architecture.
+                    Or, on x86, <texttt text="irq"/> is not in the ISA IRQ range.
+                    Or, <texttt text="depth"/> is invalid <docref>(see <autoref label="s:cspace-addressing"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_RevokeFirst">
+                <description>
+                    An IRQ handler capability for <texttt text="irq"/> has already been created.
+                </description>
+            </error>
+        </method>
+
+    </interface>
+
+    <interface name="seL4_IRQHandler" manual_name="IRQ Handler" cap_description="The IRQ handler capability.">
+
+        <method id="IRQAckIRQ" name="Ack" manual_name="Acknowledge" manual_label="irq_handleracknowledge">
+            <brief>
+                Acknowledge the receipt of an interrupt and re-enable it
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:interrupts"/>.</docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="IRQSetIRQHandler" name="SetNotification" manual_name="Set Notification" manual_label="irq_handlersetnotification">
+            <brief>
+                Set the notification which the kernel will signal on interrupts
+                controlled by the supplied IRQ handler capability
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:interrupts"/>.</docref>
+            </description>
+            <param dir="in" name="notification" type="seL4_CPtr" description="The notification which the IRQs will signal."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="notification"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="notification"/> does not have the Write right <docref>(see <autoref label="sec:cap_rights"/>)</docref>.
+                </description>
+            </error>
+        </method>
+
+        <method id="IRQClearIRQHandler" name="Clear" manual_label="irq_handlerclear">
+            <brief>
+                Clear the handler capability from the IRQ slot
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:interrupts"/>.</docref>
+            </description>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+    </interface>
+
+    <interface name="seL4_DomainSet" manual_name="Domain Set" cap_description="Capability allowing domain configuration.">
+
+        <method id="DomainSetSet" name="Set" manual_label="domainset_set">
+            <brief>
+                Change the domain of a thread.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:domains"/>.</docref>
+            </description>
+            <param dir="in" name="domain" type="seL4_Uint8" description="The thread's new domain."/>
+            <param dir="in" name="thread" type="seL4_TCB" description="Capability to the TCB which is being operated on."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="domain"/> is greater than <texttt text="CONFIG_NUM_DOMAINS"/>.
+                    Or, <texttt text="thread"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+    </interface>
+
+    <interface name="seL4_SchedControl" cap_description="Capability to a scheduling control object.">
+
+        <method id="SchedControlConfigureFlags" name="ConfigureFlags" manual_name="Configure Flags" manual_label="schedcontrol_configureflags">
+            <condition><config var="CONFIG_KERNEL_MCS"/></condition>
+            <brief>
+                Set the parameters of a scheduling context by invoking the scheduling control capability. If the scheduling context is bound to a currently running thread, the parameters will take effect immediately: that is the current budget will be increased or reduced by the difference between the new and previous budget and the replenishment time will be updated according to any difference in the period. This can result in active threads being post-poned or released depending on the nature of the parameter change and the state of the thread. Additionally, if the scheduling context was previously empty (no budget) but bound to a runnable thread, this can result in a thread running for the first time since it now has access to CPU time. This call will return seL4 Invalid Argument if the parameters are too small (smaller than the kernel WCET for this platform) or too large (will overflow the timer).
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:threads"/></docref>
+            </description>
+            <return><errorenumdesc/></return>
+            <param dir="in" name="schedcontext" type="seL4_SchedContext"
+                description="Capability to the scheduling context which is being operated on."/>
+            <param dir="in" name="budget" type="seL4_Time"
+                description="Timeslice in microseconds, when the budget expires the thread will be pre-empted."/>
+            <param dir="in" name="period" type="seL4_Time"
+                description="Period in microseconds, if equal to budget, this thread will be treated as a round-robin thread. Otherwise, sporadic servers will be used to assure the scheduling context does not exceed the budget over the specified period."/>
+            <param dir="in" name="extra_refills" type="seL4_Word"
+                description="Number of extra sporadic replenishments this scheduling context should use. Ignored for round-robin threads."/>
+            <param dir="in" name="badge" type="seL4_Word"
+                description="Identifier for this scheduling context. Delivered to timeout exception handler. Can be used to determine which scheduling context triggered the timeout." />
+            <param dir="in" name="flags" type="seL4_Word"
+                description="Bitwise OR'd set of seL4_SchedContextFlag." />
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="schedcontext"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The <texttt text="budget"/> or <texttt text="period"/> or <texttt text="extra_refills"/> is too big or too small.
+                    Or, <texttt text="budget"/> is greater than <texttt text="period"/>.
+                </description>
+            </error>
+        </method>
+
+    </interface>
+
+    <interface name="seL4_SchedContext" cap_description="Capability to the scheduling context which is being operated on.">
+
+        <method id="SchedContextBind" name="Bind" manual_label="schedcontext_bind">
+            <condition><config var="CONFIG_KERNEL_MCS"/></condition>
+            <brief>
+                Bind an object to a scheduling context. The object can be a notification object or a
+                thread.
+
+                If the object is a thread and the thread is in a runnable state and the scheduling
+                context has available budget, this will start the thread running.
+
+                If the object is a notification, when passive threads wait on the notification object and
+                a signal arrives, the passive thread will receive the scheduling context and possess it
+                until it waits on the notification object again.
+
+                This operation will fail for notification objects if the scheduling context is already
+                bound to a notification object, and for thread objects if the scheduling context is
+                already bound to a thread.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:threads"/></docref>
+            </description>
+            <return><errorenumdesc/></return>
+            <param dir="in" name="cap" type="seL4_CPtr"
+                description="Capability to a TCB or a notification object"/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> or <texttt text="cap"/> is already bound to the same type of object.
+                    Or, <texttt text="cap"/> is a TCB in the blocked state and <texttt text="_service"/> is not schedulable.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="cap"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="SchedContextUnbind" name="Unbind" manual_label="schedcontext_unbind">
+            <condition><config var="CONFIG_KERNEL_MCS"/></condition>
+            <brief>
+                Unbind any objects (threads or notification objects) from a scheduling context. This
+                will render the bound thread passive, see Section 6.1.5.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:threads"/></docref>
+            </description>
+            <return><errorenumdesc/></return>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, the current thread's TCB is bound to <texttt text="_service"/>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+
+        <method id="SchedContextUnbindObject" name="UnbindObject"
+            manual_name="Unbind Object" manual_label="schedcontext_unbindobject">
+            <condition><config var="CONFIG_KERNEL_MCS"/></condition>
+            <brief>
+                Unbind an object from a scheduling context. The object can be either a thread or a
+                notification.
+
+                If the thread being unbound is the thread that is bound to this scheduling context,
+                this will render the thread passive. However if the thread being
+                unbound received the scheduling context via scheduling context donation over IPC,
+                the scheduling context will be returned to the thread that it was originally bound to.
+
+                If the object is a notification and it is bound to the scheduling context, unbind it.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:passive"/></docref>
+            </description>
+            <return><errorenumdesc/></return>
+            <param dir="in" name="cap" type="seL4_CPtr"
+                description="Capability to a notification that is bound to the scheduling context or capability to a TCB that is bound to this scheduling context or has received it through scheduling context donation."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="cap"/> is not bound to <texttt text="_service"/>.
+                    Or, <texttt text="cap"/> is the current thread's TCB.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> or <texttt text="cap"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+        <method id="SchedContextConsumed" name="Consumed" manual_label="schedcontext_consumed">
+            <condition><config var="CONFIG_KERNEL_MCS"/></condition>
+            <brief>
+                Return the amount of time used by this scheduling context since this function was last called or a timeout exception triggered.
+            </brief>
+            <description>
+                <docref>See <autoref label="sec:threads"/></docref>
+            </description>
+            <return><errorenumdesc/></return>
+            <param dir="out" name="consumed" type="seL4_Time"
+                description="Amount consumed by this scheduling context."/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+       </method>
+       <method id="SchedContextYieldTo" name="YieldTo" manual_name="Yield To" manual_label="schedcontext_yieldto">
+          <condition><config var="CONFIG_KERNEL_MCS"/></condition>
+          <brief>
+              If a thread is currently runnable and running on this scheduling context and the scheduling context has available budget, place it at the head of the scheduling queue.
+              If the caller is at an equal priority to the thread this will result in the thread being scheduled.
+              If the caller is at a higher priority the thread will not run until the threads priority is the highest priority in the system.
+              The caller must have a maximum control priority greater than or equal to the threads priority.
+          </brief>
+          <description>
+              Capability to the scheduling context which is being operated on.
+          </description>
+          <return>
+            <docref>See <autoref label="sec:scheduling_contexts"/></docref>
+          </return>
+            <param dir="out" name="consumed" type="seL4_Time"/>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not bound to a TCB or is bound to the current thread's TCB.
+                    Or, the target thread's priority is greater than the current thread's maximum controlled priority<docref> (see <autoref label="sec:sched"/>)</docref>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                </description>
+            </error>
+        </method>
+    </interface>
+
+</api>

--- a/libsel4/include/sel4/assert.h
+++ b/libsel4/include/sel4/assert.h
@@ -32,7 +32,7 @@ void __assert_fail(const char  *str, const char *file, int line, const char *fun
  * expr as a string plus the file, line and function.
  */
 #define seL4_Assert(expr) \
-    do { if (!(expr)) { __assert_fail(#expr, __FILE__, __LINE__, __FUNCTION__); } } while(0)
+    do { if (!(expr)) { __assert_fail(#expr, __FILE__, __LINE__, __func__); } } while(0)
 
 /**
  * An assert that tests that the expr is a compile time constant and

--- a/libsel4/include/sel4/bootinfo_types.h
+++ b/libsel4/include/sel4/bootinfo_types.h
@@ -10,7 +10,7 @@
 #include <sel4/macros.h>
 
 /* caps with fixed slot positions in the root CNode */
-enum {
+enum seL4_RootCNodeCapSlots {
     seL4_CapNull                =  0, /* null cap */
     seL4_CapInitThreadTCB       =  1, /* initial thread's TCB cap */
     seL4_CapInitThreadCNode     =  2, /* initial thread's root CNode cap */
@@ -23,14 +23,11 @@ enum {
     seL4_CapBootInfoFrame       =  9, /* bootinfo frame cap */
     seL4_CapInitThreadIPCBuffer = 10, /* initial thread's IPC buffer frame cap */
     seL4_CapDomain              = 11, /* global domain controller cap */
-    seL4_CapSMMUSIDControl      = 12,  /*global SMMU SID controller cap, null cap if not supported*/
-    seL4_CapSMMUCBControl       = 13,  /*global SMMU CB controller cap, null cap if not supported*/
-#ifdef CONFIG_KERNEL_MCS
-    seL4_CapInitThreadSC        = 14, /* initial thread's scheduling context cap */
-    seL4_NumInitialCaps         = 15
-#else
-    seL4_NumInitialCaps         = 14
-#endif /* !CONFIG_KERNEL_MCS */
+    seL4_CapSMMUSIDControl      = 12, /* global SMMU SID controller cap, null cap if not supported */
+    seL4_CapSMMUCBControl       = 13, /* global SMMU CB controller cap, null cap if not supported */
+    seL4_CapInitThreadSC        = 14, /* initial thread's scheduling context cap, null cap if not supported */
+    seL4_CapSMC                 = 15, /* global SMC cap, null cap if not supported */
+    seL4_NumInitialCaps         = 16
 };
 
 /* Legacy code will have assumptions on the vspace root being a Page Directory
@@ -78,6 +75,17 @@ typedef struct seL4_BootInfo {
     /* the untypedList should be the last entry in this struct, in order
      * to make this struct easier to represent in other languages */
 } seL4_BootInfo;
+
+/* The boot info frame must be large enough to hold the seL4_BootInfo data
+ * structure. Due to internal restrictions, the size must be of the form 2^n and
+ * the minimum is one page.
+ */
+#define seL4_BootInfoFrameBits  seL4_PageBits
+#define seL4_BootInfoFrameSize  LIBSEL4_BIT(seL4_BootInfoFrameBits)
+
+SEL4_COMPILE_ASSERT(
+    invalid_seL4_BootInfoFrameSize,
+    sizeof(seL4_BootInfo) <= seL4_BootInfoFrameSize)
 
 /* If extraLen > 0, then 4K after the start of bootinfo there is a region of the
  * size extraLen that contains additional boot info data chunks. They are

--- a/libsel4/include/sel4/constants.h
+++ b/libsel4/include/sel4/constants.h
@@ -51,12 +51,10 @@ enum priorityConstants {
 
 enum seL4_MsgLimits {
     seL4_MsgLengthBits = 7,
-    seL4_MsgExtraCapBits = 2
+    seL4_MsgExtraCapBits = 2,
+    seL4_MsgMaxLength = 120
 };
 
-enum {
-    seL4_MsgMaxLength = 120,
-};
 #define seL4_MsgMaxExtraCaps (LIBSEL4_BIT(seL4_MsgExtraCapBits)-1)
 
 /* seL4_CapRights_t defined in shared_types_*.bf */

--- a/libsel4/include/sel4/macros.h
+++ b/libsel4/include/sel4/macros.h
@@ -19,7 +19,6 @@
 #define SEL4_PACKED             __attribute__((packed))
 #define SEL4_DEPRECATED(x)      __attribute__((deprecated(x)))
 #define SEL4_DEPRECATE_MACRO(x) _Pragma("deprecated") x
-#define SEL4_OFFSETOF(type, member) __builtin_offsetof(type, member)
 
 #define LIBSEL4_UNUSED          __attribute__((unused))
 #define LIBSEL4_WEAK            __attribute__((weak))

--- a/libsel4/sel4_arch_include/aarch64/interfaces/object-api-sel4-arch.xml
+++ b/libsel4/sel4_arch_include/aarch64/interfaces/object-api-sel4-arch.xml
@@ -1,0 +1,236 @@
+<?xml version="1.0" ?>
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: BSD-2-Clause
+-->
+
+<api name="ObjectApiAarch64" label_prefix="aarch64_">
+    <struct name="seL4_UserContext">
+        <member name="pc"/>
+        <member name="sp"/>
+        <member name="spsr"/>
+        <member name="x0"/>
+        <member name="x1"/>
+        <member name="x2"/>
+        <member name="x3"/>
+        <member name="x4"/>
+        <member name="x5"/>
+        <member name="x6"/>
+        <member name="x7"/>
+        <member name="x8"/>
+        <member name="x16"/>
+        <member name="x17"/>
+        <member name="x18"/>
+        <member name="x29"/>
+        <member name="x30"/>
+        <member name="x9"/>
+        <member name="x10"/>
+        <member name="x11"/>
+        <member name="x12"/>
+        <member name="x13"/>
+        <member name="x14"/>
+        <member name="x15"/>
+        <member name="x19"/>
+        <member name="x20"/>
+        <member name="x21"/>
+        <member name="x22"/>
+        <member name="x23"/>
+        <member name="x24"/>
+        <member name="x25"/>
+        <member name="x26"/>
+        <member name="x27"/>
+        <member name="x28"/>
+        <member name="tpidr_el0"/>
+        <member name="tpidrro_el0"/>
+    </struct>
+    <struct name="seL4_ARM_SMCContext">
+        <member name="x0"/>
+        <member name="x1"/>
+        <member name="x2"/>
+        <member name="x3"/>
+        <member name="x4"/>
+        <member name="x5"/>
+        <member name="x6"/>
+        <member name="x7"/>
+    </struct>
+    <interface name="seL4_ARM_VSpace" manual_name="Page Global Directory"
+        cap_description="Capability to the top level translation table being operated on.">
+        <method id="ARMVSpaceClean_Data" name="Clean_Data" manual_label="vspace_clean"
+            manual_name="Clean Data">
+                <brief>
+                    Clean cached pages within a top level translation table
+                </brief>
+                <description>
+                    <docref>See <autoref label="ch:vspace"/>.</docref>
+                </description>
+            <param dir="in" name="start" type="seL4_Word"
+            description="Start address"/>
+            <param dir="in" name="end" type="seL4_Word"
+            description="End address"/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="_service"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="end"/> is in the kernel virtual address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="start"/> is greater than or equal to <texttt text="end"/>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The specified range crosses a page boundary.
+                </description>
+            </error>
+        </method>
+        <method id="ARMVSpaceInvalidate_Data" name="Invalidate_Data"
+            manual_name="Invalidate Data" manual_label="vspace_invalidate">
+                <brief>
+                    Invalidate cached pages within a top level translation table
+                </brief>
+             <description>
+                 <docref>See <autoref label="ch:vspace"/>.</docref>
+             </description>
+            <param dir="in" name="start" type="seL4_Word"
+            description="Start address"/>
+            <param dir="in" name="end" type="seL4_Word"
+            description="End address"/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="_service"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="end"/> is in the kernel virtual address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="start"/> is greater than or equal to <texttt text="end"/>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The specified range crosses a page boundary.
+                </description>
+            </error>
+        </method>
+        <method id="ARMVSpaceCleanInvalidate_Data" name="CleanInvalidate_Data"
+            manual_name="Clean and Invalidate Data" manual_label="vspace_clean_invalidate">
+                <brief>
+                    Clean and invalidate cached pages within a top level translation table
+                </brief>
+             <description>
+                 <docref>See <autoref label="ch:vspace"/>.</docref>
+             </description>
+            <param dir="in" name="start" type="seL4_Word"
+            description="Start address"/>
+            <param dir="in" name="end" type="seL4_Word"
+            description="End address"/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="_service"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="end"/> is in the kernel virtual address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="start"/> is greater than or equal to <texttt text="end"/>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The specified range crosses a page boundary.
+                </description>
+            </error>
+        </method>
+        <method id="ARMVSpaceUnify_Instruction" name="Unify_Instruction"
+            manual_name="Unify Instruction" manual_label="vspace_unify_instruction">
+                <brief>
+                    Clean and invalidate cached instruction pages to point of unification
+                </brief>
+             <description>
+                 <docref>See <autoref label="ch:vspace"/>.</docref>
+             </description>
+             <param dir="in" name="start" type="seL4_Word"
+             description="Start address"/>
+             <param dir="in" name="end" type="seL4_Word"
+	     description="End address"/>
+            <error name="seL4_FailedLookup">
+                <description>
+                    The <texttt text="_service"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_IllegalOperation">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="end"/> is in the kernel virtual address range.
+                </description>
+            </error>
+            <error name="seL4_InvalidArgument">
+                <description>
+                    The <texttt text="start"/> is greater than or equal to <texttt text="end"/>.
+                </description>
+            </error>
+            <error name="seL4_InvalidCapability">
+                <description>
+                    The <texttt text="_service"/> is a CPtr to a capability of the wrong type.
+                    Or, <texttt text="_service"/> is not assigned to an ASID pool.
+                </description>
+            </error>
+            <error name="seL4_RangeError">
+                <description>
+                    The specified range crosses a page boundary.
+                </description>
+            </error>
+        </method>
+    </interface>
+    <interface name="seL4_ARM_SMC" manual_name="SMC" cap_description="Capability to allow threads to make Secure Monitor Calls.">
+        <method id="ARMSMCCall" name="Call" manual_name="SMC Call" manual_label="smc_call">
+            <brief>
+                Tell the kernel to make the real SMC call.
+            </brief>
+            <description>
+                Takes x0-x7 as arguments to an SMC call which are defined as a seL4_ARM_SMCContext
+                struct. The kernel makes the SMC call and then returns the results as a
+                new seL4_ARM_SMCContext.
+            </description>
+            <param dir="in" name="smc_args" type="seL4_ARM_SMCContext"
+                description="The structure that has the provided arguments."/>
+            <param dir="out" name="smc_response" type="seL4_ARM_SMCContext"
+                description="The structure to capture the responses."/>
+        </method>
+    </interface>
+</api>

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/constants.h
@@ -52,8 +52,6 @@ typedef enum {
     SEL4_FORCE_LONG_ENUM(seL4_VMFault_Msg),
 } seL4_VMFault_Msg;
 
-#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-
 typedef enum {
     seL4_VGICMaintenance_IDX,
     seL4_VGICMaintenance_Length,
@@ -62,6 +60,7 @@ typedef enum {
 
 typedef enum {
     seL4_VPPIEvent_IRQ,
+    seL4_VPPIEvent_Length,
     SEL4_FORCE_LONG_ENUM(seL4_VPPIEvent_Msg),
 } seL4_VPPIEvent_Msg;
 
@@ -97,10 +96,8 @@ typedef enum {
     /* thread pointer/ID registers EL0/EL1 */
     seL4_VCPUReg_TPIDR_EL1,
 
-#if CONFIG_MAX_NUM_NODES > 1
     /* Virtualisation Multiprocessor ID Register */
     seL4_VCPUReg_VMPIDR_EL2,
-#endif /* CONFIG_MAX_NUM_NODES > 1 */
 
     /* general registers x0 to x30 have been saved by traps.S */
     seL4_VCPUReg_SP_EL1,
@@ -114,9 +111,8 @@ typedef enum {
     seL4_VCPUReg_CNTKCTL_EL1,
 
     seL4_VCPUReg_Num,
+    SEL4_FORCE_LONG_ENUM(seL4_VCPUReg),
 } seL4_VCPUReg;
-
-#endif /* CONFIG_ARM_HYPERVISOR_SUPPORT */
 
 #ifdef CONFIG_KERNEL_MCS
 typedef enum {
@@ -163,7 +159,7 @@ typedef enum {
     seL4_Timeout_Consumed,
     seL4_Timeout_Length,
     SEL4_FORCE_LONG_ENUM(seL4_Timeout_Msg)
-} seL4_TimeoutMsg;
+} seL4_Timeout_Msg;
 #endif
 #endif /* !__ASSEMBLER__ */
 
@@ -187,41 +183,21 @@ typedef enum {
 #define seL4_PageTableEntryBits 3
 #define seL4_PageTableIndexBits 9
 
-#define seL4_PageDirBits 12
-#define seL4_PageDirEntryBits 3
-#define seL4_PageDirIndexBits 9
-
 #define seL4_NumASIDPoolsBits 7
 #define seL4_ASIDPoolBits 12
 #define seL4_ASIDPoolIndexBits 9
 #define seL4_IOPageTableBits 12
 #define seL4_WordSizeBits 3
 
-#define seL4_PUDEntryBits 3
+#define seL4_VSpaceEntryBits 3
 
 #if defined(CONFIG_ARM_HYPERVISOR_SUPPORT) && defined (CONFIG_ARM_PA_SIZE_BITS_40)
 /* for a 3 level translation, we skip the PGD */
-#define seL4_PGDBits 0
-#define seL4_PGDEntryBits 0
-#define seL4_PGDIndexBits    0
-
-#define seL4_PUDBits 13
-#define seL4_PUDIndexBits 10
-
-#define seL4_VSpaceBits seL4_PUDBits
-#define seL4_VSpaceIndexBits seL4_PUDIndexBits
-#define seL4_ARM_VSpaceObject seL4_ARM_PageUpperDirectoryObject
+#define seL4_VSpaceBits 13
+#define seL4_VSpaceIndexBits 10
 #else
-#define seL4_PGDBits 12
-#define seL4_PGDEntryBits 3
-#define seL4_PGDIndexBits    9
-
-#define seL4_PUDBits 12
-#define seL4_PUDIndexBits 9
-
-#define seL4_VSpaceBits seL4_PGDBits
-#define seL4_VSpaceIndexBits seL4_PGDIndexBits
-#define seL4_ARM_VSpaceObject seL4_ARM_PageGlobalDirectoryObject
+#define seL4_VSpaceBits 12
+#define seL4_VSpaceIndexBits 9
 #endif
 
 #define seL4_ARM_VCPUBits   12
@@ -236,10 +212,8 @@ typedef enum {
 
 #ifndef __ASSEMBLER__
 SEL4_SIZE_SANITY(seL4_PageTableEntryBits, seL4_PageTableIndexBits, seL4_PageTableBits);
-SEL4_SIZE_SANITY(seL4_PageDirEntryBits, seL4_PageDirIndexBits, seL4_PageDirBits);
 SEL4_SIZE_SANITY(seL4_WordSizeBits, seL4_ASIDPoolIndexBits, seL4_ASIDPoolBits);
-SEL4_SIZE_SANITY(seL4_PGDEntryBits, seL4_PGDIndexBits, seL4_PGDBits);
-SEL4_SIZE_SANITY(seL4_PUDEntryBits, seL4_PUDIndexBits, seL4_PUDBits);
+SEL4_SIZE_SANITY(seL4_VSpaceEntryBits, seL4_VSpaceIndexBits, seL4_VSpaceBits);
 #endif
 
 #ifdef CONFIG_ENABLE_BENCHMARKS

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/deprecated.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/deprecated.h
@@ -6,4 +6,40 @@
 
 #pragma once
 
-/* nothing here */
+#define seL4_ARM_PageDirectory seL4_ARM_PageTable;
+#define seL4_ARM_PageDirectory_Map seL4_ARM_PageTable_Map
+#define seL4_ARM_PageDirectory_Unmap seL4_ARM_PageTable_Unmap
+#define ARMPageDirectoryMap ARMPageTableMap
+#define ARMPageDirectoryUnmap ARMPageTableUnmap
+
+#define seL4_PageDirBits seL4_PageTableBits
+#define seL4_PageDirEntryBits seL4_PageTableEntryBits
+#define seL4_PageDirIndexBits seL4_PageTableIndexBits
+#define seL4_ARM_PageDirectoryObject seL4_ARM_PageTableObject
+
+#define seL4_PUDEntryBits 3
+
+#if defined(CONFIG_ARM_HYPERVISOR_SUPPORT) && defined (CONFIG_ARM_PA_SIZE_BITS_40)
+
+#define seL4_PGDBits 0
+#define seL4_PGDEntryBits 0
+#define seL4_PGDIndexBits    0
+
+#define seL4_PUDBits 13
+#define seL4_PUDIndexBits 10
+#define seL4_ARM_PageUpperDirectoryObject seL4_ARM_VSpaceObject
+
+#else
+
+#define seL4_PGDBits 12
+#define seL4_PGDEntryBits 3
+#define seL4_PGDIndexBits    9
+
+#define seL4_PUDBits 12
+#define seL4_PUDIndexBits 9
+#define seL4_ARM_PageGlobalDirectoryObject seL4_ARM_VSpaceObject
+#define seL4_ARM_PageUpperDirectoryObject seL4_ARM_PageTableObject
+#define seL4_ARM_PageUpperDirectory seL4_ARM_PageTable;
+#define seL4_ARM_PageUpperDirectory_Map seL4_ARM_PageTable_Map
+#define seL4_ARM_PageUpperDirectory_Unmap seL4_ARM_PageTable_Unmap
+#endif

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/objecttype.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/objecttype.h
@@ -8,7 +8,6 @@
 
 typedef enum _mode_object {
     seL4_ARM_HugePageObject = seL4_NonArchObjectTypeCount,
-    seL4_ARM_PageUpperDirectoryObject,
-    seL4_ARM_PageGlobalDirectoryObject,
+    seL4_ARM_VSpaceObject,
     seL4_ModeObjectTypeCount
 } seL4_ModeObjectType;

--- a/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/types.h
+++ b/libsel4/sel4_arch_include/aarch64/sel4/sel4_arch/types.h
@@ -22,3 +22,8 @@ typedef struct seL4_UserContext_ {
     /* Thread ID registers */
     seL4_Word tpidr_el0, tpidrro_el0;
 } seL4_UserContext;
+
+typedef struct seL4_ARM_SMCContext_ {
+    /* register arguments */
+    seL4_Word x0, x1, x2, x3, x4, x5, x6, x7;
+} seL4_ARM_SMCContext;

--- a/libsel4/sel4_arch_include/riscv64/interfaces/object-api-sel4-arch.xml
+++ b/libsel4/sel4_arch_include/riscv64/interfaces/object-api-sel4-arch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: BSD-2-Clause
+-->
+
+<api>
+</api>

--- a/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
+++ b/libsel4/sel4_arch_include/riscv64/sel4/sel4_arch/constants.h
@@ -121,7 +121,7 @@ typedef enum {
     seL4_Timeout_Data,
     seL4_Timeout_Consumed,
     seL4_Timeout_Length,
-} seL4_TimeoutMsg;
+} seL4_Timeout_Msg;
 #endif
 #endif /* __ASSEMBLER__ */
 

--- a/libsel4/tools/syscall_stub_gen_rs.py
+++ b/libsel4/tools/syscall_stub_gen_rs.py
@@ -432,14 +432,20 @@ def generate_stub(arch, wordsize, interface_name, method_name, method_id, input_
     return "\n".join(result) + "\n"
 
 
-def generate_stub_file(arch, wordsize, input_files, output_file, use_only_ipc_buffer, mcs):
+def generate_stub_file(arch, input_files, output_file, use_only_ipc_buffer, mcs, args):
     """
     Generate a header file containing system call stubs for seL4.
     """
     result = []
+    
+    # Ensure architecture looks sane.
+    if arch not in syscall_stub_gen.WORD_SIZE_BITS_ARCH.keys():
+        raise Exception(f"Invalid architecture: {arch}")
+
+    wordsize = syscall_stub_gen.WORD_SIZE_BITS_ARCH[arch]
 
     data_types = syscall_stub_gen.init_data_types(wordsize)
-    arch_types = syscall_stub_gen.init_arch_types(wordsize)
+    arch_types = syscall_stub_gen.init_arch_types(wordsize, args)
 
     # Parse XML
     methods = []
@@ -522,6 +528,8 @@ def process_args():
                         help="Architecture to generate stubs for.")
     parser.add_argument("--mcs", dest="mcs", action="store_true",
                         help="Generate MCS api.")
+    parser.add_argument("--x86-vtx-64-bit-guests", dest="x86_vtx_64bit", action="store_true", default=False,
+                        help="Whether the vtx VCPU objects need to be large enough for 64-bit guests.")
 
     parser.add_argument("files", metavar="FILES", nargs="+",
                         help="Input XML files.")
@@ -530,13 +538,10 @@ def process_args():
 
 
 def main():
-
     parser = process_args()
     args = parser.parse_args()
-
-    wordsize = syscall_stub_gen.WORD_SIZE_BITS_ARCH[args.arch]
     # Generate the stubs.
-    generate_stub_file(args.arch, wordsize, args.files, args.output, args.buffer, args.mcs)
+    generate_stub_file(args.arch, args.files, args.output, args.buffer, args.mcs, args)
 
 
 if __name__ == "__main__":

--- a/src/arch/arm/64/machine/capdl.c
+++ b/src/arch/arm/64/machine/capdl.c
@@ -19,21 +19,19 @@ word_t get_tcb_sp(tcb_t *tcb)
 
 #ifdef CONFIG_PRINTING
 
-static void obj_frame_print_attrs(lookupFrame_ret_t ret);
-static void cap_frame_print_attrs_pud(pude_t *pudSlot);
-static void cap_frame_print_attrs_pd(pde_t *pdSlot);
+static void obj_frame_print_attrs(vm_page_size_t frameSize, paddr_t frameBase);
 static void cap_frame_print_attrs_pt(pte_t *ptSlot);
 static void cap_frame_print_attrs_impl(word_t SH, word_t AP, word_t NXN);
 static void cap_frame_print_attrs_vptr(word_t vptr, cap_t vspace);
 
-static void _cap_frame_print_attrs_vptr(word_t vptr, vspace_root_t *vspaceRoot);
+// static void _cap_frame_print_attrs_vptr(word_t vptr, vspace_root_t *vspaceRoot);
 
-static void arm64_obj_pt_print_slots(pde_t *pdSlot);
-static void arm64_obj_pd_print_slots(pude_t *pudSlot);
+static void arm64_obj_pt_print_slots(pte_t *pdSlot);
+static void arm64_obj_pd_print_slots(pte_t *pudSlot);
 static void arm64_obj_pud_print_slots(void *pgdSlot_or_vspace);
 
-static void arm64_cap_pt_print_slots(pde_t *pdSlot, vptr_t vptr);
-static void arm64_cap_pd_print_slots(pude_t *pudSlot, vptr_t vptr);
+static void arm64_cap_pt_print_slots(pte_t *pdSlot, vptr_t vptr);
+static void arm64_cap_pd_print_slots(pte_t *pudSlot, vptr_t vptr);
 static void arm64_cap_pud_print_slots(void *pgdSlot_or_vspace, vptr_t vptr);
 
 /* Stage-1 access permissions:
@@ -55,25 +53,11 @@ static void arm64_cap_pud_print_slots(void *pgdSlot_or_vspace, vptr_t vptr);
  *  EL2 still uses the Stage-1 AP format.
  */
 /* use when only have access to pte of frames */
-static void cap_frame_print_attrs_pud(pude_t *pudSlot)
-{
-    cap_frame_print_attrs_impl(pude_pude_1g_ptr_get_SH(pudSlot),
-                               pude_pude_1g_ptr_get_AP(pudSlot),
-                               pude_pude_1g_ptr_get_UXN(pudSlot));
-}
-
-static void cap_frame_print_attrs_pd(pde_t *pdSlot)
-{
-    cap_frame_print_attrs_impl(pde_pde_large_ptr_get_SH(pdSlot),
-                               pde_pde_large_ptr_get_AP(pdSlot),
-                               pde_pde_large_ptr_get_UXN(pdSlot));
-}
-
 static void cap_frame_print_attrs_pt(pte_t *ptSlot)
 {
-    cap_frame_print_attrs_impl(pte_ptr_get_SH(ptSlot),
-                               pte_ptr_get_AP(ptSlot),
-                               pte_ptr_get_UXN(ptSlot));
+    cap_frame_print_attrs_impl(pte_pte_page_ptr_get_SH(ptSlot),
+                               pte_pte_page_ptr_get_AP(ptSlot),
+                               pte_pte_page_ptr_get_UXN(ptSlot));
 }
 
 static void cap_frame_print_attrs_impl(word_t SH, word_t AP, word_t NXN)
@@ -121,103 +105,88 @@ static void cap_frame_print_attrs_impl(word_t SH, word_t AP, word_t NXN)
 }
 
 /* use when only have access to vptr of frames */
-static void _cap_frame_print_attrs_vptr(word_t vptr, vspace_root_t *vspace)
-{
-    lookupPUDSlot_ret_t pudSlot = lookupPUDSlot(vspace, vptr);
-    if (pudSlot.status != EXCEPTION_NONE) {
-        return;
-    }
+// static void _cap_frame_print_attrs_vptr(word_t vptr, vspace_root_t *vspace)
+// {
+//     lookupPTSlot_ret_t ret = lookupPTSlot(vspace, vptr);
 
-    switch (pude_ptr_get_pude_type(pudSlot.pudSlot)) {
-    case pude_pude_1g:
-        printf("frame_%p_%04lu ", pudSlot.pudSlot, GET_PUD_INDEX(vptr));
-        cap_frame_print_attrs_pud(pudSlot.pudSlot);
-        break;
+//     /* Check that the returned slot is a page. */
+//     if (!pte_ptr_get_valid(ret.ptSlot) ||
+//         (pte_pte_table_ptr_get_present(ret.ptSlot) && ret.ptBitsLeft > PAGE_BITS)) {
+//         assert(0);
+//     }
 
-    case pude_pude_pd: {
-        pde_t *pd = paddr_to_pptr(pude_pude_pd_ptr_get_pd_base_address(pudSlot.pudSlot));
-        pde_t *pdSlot = pd + GET_PD_INDEX(vptr);
+//     word_t table_index;
+//     switch (ret.ptBitsLeft) {
 
-        switch (pde_ptr_get_pde_type(pdSlot)) {
-        case pde_pde_large:
-            printf("frame_%p_%04lu ", pdSlot, GET_PD_INDEX(vptr));
-            cap_frame_print_attrs_pd(pdSlot);
-            break;
+//     case ARMHugePage:
+//         table_index = GET_UPT_INDEX(vptr, ULVL_FRM_ARM_PT_LVL(1));
+//         break;
+//     case ARMLargePage:
+//         table_index = GET_UPT_INDEX(vptr, ULVL_FRM_ARM_PT_LVL(2));
+//         break;
+//     case ARMSmallPage:
+//         table_index = GET_UPT_INDEX(vptr, ULVL_FRM_ARM_PT_LVL(3));
+//         break;
+//     default:
+//         assert(0);
 
-        case pde_pde_small: {
-            pte_t *pt = paddr_to_pptr(pde_pde_small_ptr_get_pt_base_address(pdSlot));
-            pte_t *ptSlot = pt + GET_PT_INDEX(vptr);
+//     }
+//     printf("frame_%p_%04lu ", ret.ptSlot, table_index);
+//     cap_frame_print_attrs_pt(ret.ptSlot);
+// }
 
-            if (pte_ptr_get_present(ptSlot)) {
-                printf("frame_%p_%04lu ", ptSlot, GET_PT_INDEX(vptr));
-                cap_frame_print_attrs_pt(ptSlot);
-                break;
-            } else {
-                return;
-            }
-        }
-        default:
-            assert(0);
-        }
-        break;
-    }
-    default:
-        assert(0);
-    }
-}
-
-void cap_frame_print_attrs_vptr(word_t vptr, cap_t vspace)
-{
-    _cap_frame_print_attrs_vptr(vptr, VSPACE_PTR(pptr_of_cap(vspace)));
-}
+// void cap_frame_print_attrs_vptr(word_t vptr, cap_t vspace)
+// {
+//     _cap_frame_print_attrs_vptr(vptr, VSPACE_PTR(pptr_of_cap(vspace)));
+// }
 
 /*
  * print object slots
  */
-static void arm64_cap_pt_print_slots(pde_t *pdSlot, vptr_t vptr)
+static void arm64_cap_pt_print_slots(pte_t *pdSlot, vptr_t vptr)
 {
-    pte_t *pt = paddr_to_pptr(pde_pde_small_ptr_get_pt_base_address(pdSlot));
-    printf("pt_%p_%04lu {\n", pdSlot, GET_PD_INDEX(vptr));
+    pte_t *pt = paddr_to_pptr(pte_pte_table_ptr_get_pt_base_address(pdSlot));
+    printf("pt_%p_%04lu {\n", pdSlot, GET_UPT_INDEX(vptr, ULVL_FRM_ARM_PT_LVL(2)));
 
-    for (word_t i = 0; i < BIT(PT_INDEX_OFFSET + PT_INDEX_BITS); i += (1 << PT_INDEX_OFFSET)) {
-        pte_t *ptSlot = pt + GET_PT_INDEX(i);
+    for (word_t i = 0; i < BIT(PT_INDEX_BITS); i ++) {
+        pte_t *ptSlot = pt + i;
 
-        if (pte_ptr_get_present(ptSlot)) {
+        if (pte_4k_page_ptr_get_present(ptSlot)) {
             // print pte entries
-            printf("0x%lx: frame_%p_%04lu", GET_PT_INDEX(i), ptSlot, GET_PT_INDEX(i));
+            printf("0x%lx: frame_%p_%04lu", i, ptSlot, i);
             cap_frame_print_attrs_pt(ptSlot);
         }
     }
     printf("}\n"); /* pt */
 }
 
-static void arm64_cap_pd_print_slots(pude_t *pudSlot, vptr_t vptr)
+static void arm64_cap_pd_print_slots(pte_t *pudSlot, vptr_t vptr)
 {
-    printf("pd_%p_%04lu {\n", pudSlot, GET_PUD_INDEX(vptr));
-    pde_t *pd = paddr_to_pptr(pude_pude_pd_ptr_get_pd_base_address(pudSlot));
+    printf("pd_%p_%04lu {\n", pudSlot, GET_UPT_INDEX(vptr, ULVL_FRM_ARM_PT_LVL(1)));
+    pte_t *pd = paddr_to_pptr(pte_pte_table_ptr_get_pt_base_address(pudSlot));
 
-    for (word_t i = 0; i < BIT(PD_INDEX_OFFSET + PD_INDEX_BITS); i += (1 << PD_INDEX_OFFSET)) {
-        pde_t *pdSlot = pd + GET_PD_INDEX(i);
+    for (word_t i = 0; i < BIT(PT_INDEX_BITS); i++) {
+        pte_t *pdSlot = pd + i;
 
-        switch (pde_ptr_get_pde_type(pdSlot)) {
+        switch (pte_ptr_get_pte_type(pdSlot)) {
 
-        case pde_pde_large:
-            printf("0x%lx: frame_%p_%04lu", GET_PD_INDEX(i), pdSlot, GET_PD_INDEX(i));
-            cap_frame_print_attrs_pd(pdSlot);
+        case pte_pte_page:
+            printf("0x%lx: frame_%p_%04lu", i, pdSlot, i);
+            cap_frame_print_attrs_pt(pdSlot);
             break;
 
-        case pde_pde_small:
-            printf("0x%lx: pt_%p_%04lu\n", GET_PD_INDEX(i), pdSlot, GET_PD_INDEX(i));
+        case pte_pte_table:
+            printf("0x%lx: pt_%p_%04lu\n", i, pdSlot, i);
             break;
         }
     }
 
     printf("}\n"); /* pd */
 
-    for (word_t i = 0; i < BIT(PD_INDEX_OFFSET + PD_INDEX_BITS); i += (1 << PD_INDEX_OFFSET)) {
-        pde_t *pdSlot = pd + GET_PD_INDEX(i);
-        if (pde_ptr_get_pde_type(pdSlot) == pde_pde_small) {
-            arm64_cap_pt_print_slots(pdSlot, i);
+    for (word_t i = 0; i < BIT(PT_INDEX_BITS); i++) {
+        pte_t *pdSlot = pd + i;
+        if (pte_ptr_get_pte_type(pdSlot) == pte_pte_table) {
+            arm64_cap_pt_print_slots(pdSlot, vptr + (i * GET_ULVL_PGSIZE(ULVL_FRM_ARM_PT_LVL(2))));
         }
     }
 }
@@ -225,26 +194,28 @@ static void arm64_cap_pd_print_slots(pude_t *pudSlot, vptr_t vptr)
 static void arm64_cap_pud_print_slots(void *pgdSlot_or_vspace, vptr_t vptr)
 {
 #ifdef AARCH64_VSPACE_S2_START_L1
-    pude_t *pud = pgdSlot_or_vspace;
+    pte_t *pud = pgdSlot_or_vspace;
+    word_t index_bits = seL4_VSpaceIndexBits;
     printf("%p_pd {\n", pgdSlot_or_vspace);
 #else
-    pude_t *pud = paddr_to_pptr(pgde_pgde_pud_ptr_get_pud_base_address(pgdSlot_or_vspace));
-    printf("pud_%p_%04lu {\n", pgdSlot_or_vspace, GET_PGD_INDEX(vptr));
+    pte_t *pud = paddr_to_pptr(pte_pte_table_ptr_get_pt_base_address(pgdSlot_or_vspace));
+    word_t index_bits = seL4_PageTableIndexBits;
+    printf("pud_%p_%04lu {\n", pgdSlot_or_vspace, GET_UPT_INDEX(vptr, ULVL_FRM_ARM_PT_LVL(0)));
 #endif
 
-    for (word_t i = 0; i < BIT(PUD_INDEX_OFFSET + UPUD_INDEX_BITS); i += (1 << PUD_INDEX_OFFSET)) {
-        pude_t *pudSlot = pud + GET_PUD_INDEX(i);
-        if (pude_ptr_get_pude_type(pudSlot) == pude_pude_pd) {
-            printf("0x%lx: pd_%p_%04lu\n", GET_PUD_INDEX(i), pudSlot, GET_PUD_INDEX(i));
+    for (word_t i = 0; i < BIT(index_bits); i++) {
+        pte_t *pudSlot = pud + i;
+        if (pte_ptr_get_pte_type(pudSlot) == pte_pte_table) {
+            printf("0x%lx: pd_%p_%04lu\n", i, pudSlot, i);
         }
     }
 
     printf("}\n"); /* pgd/pud */
 
-    for (word_t i = 0; i < BIT(PUD_INDEX_OFFSET + UPUD_INDEX_BITS); i += (1 << PUD_INDEX_OFFSET)) {
-        pude_t *pudSlot = pud + GET_PUD_INDEX(i);
-        if (pude_ptr_get_pude_type(pudSlot) == pude_pude_pd) {
-            arm64_cap_pd_print_slots(pudSlot, i);
+    for (word_t i = 0; i < BIT(index_bits); i++) {
+        pte_t *pudSlot = pud + GET_UPT_INDEX(i, ULVL_FRM_ARM_PT_LVL(1));
+        if (pte_ptr_get_pte_type(pudSlot) == pte_pte_table) {
+            arm64_cap_pd_print_slots(pudSlot, vptr + (i * GET_ULVL_PGSIZE(ULVL_FRM_ARM_PT_LVL(1))));
         }
     }
 }
@@ -253,7 +224,7 @@ void obj_vtable_print_slots(tcb_t *tcb)
 {
     if (isVTableRoot(TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap) && !seen(TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap)) {
         add_to_seen(TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap);
-        vspace_root_t *vspace = cap_vtable_root_get_basePtr(TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap);
+        vspace_root_t *vspace = VSPACE_PTR(cap_vspace_cap_get_capVSBasePtr(TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap));
 
         /*
         * ARM hyp uses 3 level translation rather than the usual 4 level.
@@ -263,18 +234,18 @@ void obj_vtable_print_slots(tcb_t *tcb)
         arm64_cap_pud_print_slots(vspace, 0);
 #else
         printf("%p_pd {\n", vspace);
-        for (word_t i = 0; i < BIT(PGD_INDEX_OFFSET + PGD_INDEX_BITS); i += (1UL << PGD_INDEX_OFFSET)) {
-            lookupPGDSlot_ret_t pgdSlot = lookupPGDSlot(vspace, i);
-            if (pgde_pgde_pud_ptr_get_present(pgdSlot.pgdSlot)) {
-                printf("0x%lx: pud_%p_%04lu\n", GET_PGD_INDEX(i), pgdSlot.pgdSlot, GET_PGD_INDEX(i));
+        for (word_t i = 0; i < PT_INDEX_BITS; i++) {
+            pte_t *ptSlot = vspace + i;
+            if (pte_pte_table_ptr_get_present(ptSlot)) {
+                printf("0x%lx: pud_%p_%04lu\n", i, ptSlot, i);
             }
         }
         printf("}\n"); /* pd */
 
-        for (word_t i = 0; i < BIT(PGD_INDEX_OFFSET + PGD_INDEX_BITS); i += (1UL << PGD_INDEX_OFFSET)) {
-            lookupPGDSlot_ret_t pgdSlot = lookupPGDSlot(vspace, i);
-            if (pgde_pgde_pud_ptr_get_present(pgdSlot.pgdSlot)) {
-                arm64_cap_pud_print_slots(pgdSlot.pgdSlot, i);
+        for (word_t i = 0; i < PT_INDEX_BITS; i++) {
+            pte_t *ptSlot = vspace + i;
+            if (pte_pte_table_ptr_get_present(ptSlot)) {
+                arm64_cap_pud_print_slots(ptSlot, i * GET_ULVL_PGSIZE(0));
             }
         }
 #endif
@@ -285,106 +256,90 @@ void print_ipc_buffer_slot(tcb_t *tcb)
 {
     word_t vptr = tcb->tcbIPCBuffer;
     printf("ipc_buffer_slot: ");
-    cap_frame_print_attrs_vptr(vptr, TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap);
+    // cap_frame_print_attrs_vptr(vptr, TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap);
 }
 
 void print_cap_arch(cap_t cap)
 {
 
-    switch (cap_get_capType(cap)) {
-    case cap_page_table_cap: {
-        asid_t asid = cap_page_table_cap_get_capPTMappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
-        vptr_t vptr = cap_page_table_cap_get_capPTMappedAddress(cap);
-        if (asid) {
-            printf("pt_%p_%04lu (asid: %lu)\n",
-                   lookupPDSlot(find_ret.vspace_root, vptr).pdSlot, GET_PD_INDEX(vptr), (long unsigned int)asid);
-        } else {
-            printf("pt_%p_%04lu\n", lookupPDSlot(find_ret.vspace_root, vptr).pdSlot, GET_PD_INDEX(vptr));
-        }
-        break;
-    }
-    case cap_page_directory_cap: {
-        asid_t asid = cap_page_directory_cap_get_capPDMappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
-        vptr_t vptr = cap_page_directory_cap_get_capPDMappedAddress(cap);
-        if (asid) {
-            printf("pd_%p_%04lu (asid: %lu)\n",
-                   lookupPUDSlot(find_ret.vspace_root, vptr).pudSlot, GET_PUD_INDEX(vptr), (long unsigned int)asid);
-        } else {
-            printf("pd_%p_%04lu\n",
-                   lookupPUDSlot(find_ret.vspace_root, vptr).pudSlot, GET_PUD_INDEX(vptr));
-        }
-        break;
-    }
-    case cap_page_upper_directory_cap: {
-        asid_t asid = cap_page_upper_directory_cap_get_capPUDMappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
-        vptr_t vptr = cap_page_upper_directory_cap_get_capPUDMappedAddress(cap);
+//     switch (cap_get_capType(cap)) {
+//     case cap_page_table_cap: {
+//         asid_t asid = cap_page_table_cap_get_capPTMappedASID(cap);
+//         vptr_t vptr = cap_page_table_cap_get_capPTMappedAddress(cap);
+//         pte_t *target_pt = PT_PTR(cap_page_table_cap_get_capPTBasePtr(cap));
 
-#ifdef AARCH64_VSPACE_S2_START_L1
-        if (asid) {
-            printf("pud_%p_%04lu (asid: %lu)\n",
-                   find_ret.vspace_root, GET_PGD_INDEX(vptr), (long unsigned int)asid);
-        } else {
-            printf("pud_%p_%04lu\n", find_ret.vspace_root, GET_PGD_INDEX(vptr));
-        }
-#else
-        if (asid) {
-            printf("pud_%p_%04lu (asid: %lu)\n",
-                   lookupPGDSlot(find_ret.vspace_root, vptr).pgdSlot, GET_PGD_INDEX(vptr), (long unsigned int)asid);
-        } else {
-            printf("pud_%p_%04lu\n", lookupPGDSlot(find_ret.vspace_root, vptr).pgdSlot, GET_PGD_INDEX(vptr));
-        }
-#endif
-        break;
-    }
-    case cap_page_global_directory_cap: {
-        asid_t asid = cap_page_global_directory_cap_get_capPGDMappedASID(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
-        if (asid) {
-            printf("%p_pd (asid: %lu)\n",
-                   find_ret.vspace_root, (long unsigned int)asid);
-        } else {
-            printf("%p_pd\n", find_ret.vspace_root);
-        }
-        break;
-    }
-    case cap_asid_control_cap: {
-        /* only one in the system */
-        printf("asid_control\n");
-        break;
-    }
-    case cap_frame_cap: {
-        vptr_t vptr = cap_frame_cap_get_capFMappedAddress(cap);
-        findVSpaceForASID_ret_t find_ret = findVSpaceForASID(cap_frame_cap_get_capFMappedASID(cap));
-        assert(find_ret.status == EXCEPTION_NONE);
-        _cap_frame_print_attrs_vptr(vptr, find_ret.vspace_root);
-        break;
-    }
-    case cap_asid_pool_cap: {
-        printf("%p_asid_pool\n", (void *)cap_asid_pool_cap_get_capASIDPool(cap));
-        break;
-    }
-#ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
-    case cap_vcpu_cap: {
-        printf("%p_vcpu\n", (void *)cap_vcpu_cap_get_capVCPUPtr(cap));
-        break;
-    }
-#endif
+//         findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
+//         pte_t *ptSlot = NULL;
+//         pte_t *pt = (pte_t *)find_ret.vspace_root;
+//         word_t level;
+//         for (level = 0; level < UPT_LEVELS - 1 && pt != target_pt; level++) {
+//             ptSlot = pt + GET_UPT_INDEX(vptr, level);
+//             if (unlikely(!pte_pte_table_ptr_get_present(ptSlot))) {
+//                 /* couldn't find it */
+//                 break;
+//             }
+//             pt = paddr_to_pptr(pte_pte_table_ptr_get_pt_base_address(ptSlot));
+//         }
+//         if (pt != target_pt) {
+//             /* didn't find it */
+//             break;
+//         }
 
-        /* ARM specific caps */
-#ifdef CONFIG_TK1_SMMU
-    case cap_io_space_cap: {
-        printf("%p_io_space\n", (void *)cap_io_space_cap_get_capModuleID(cap));
-        break;
-    }
-#endif
-    default: {
-        printf("[unknown cap %lu]\n", (long unsigned int)cap_get_capType(cap));
-        break;
-    }
-    }
+
+//         if (asid) {
+//             printf("pt_%p_%04lu (asid: %lu)\n",
+//                    target_pt, GET_UPT_INDEX(vptr, level), (long unsigned int)asid);
+//         } else {
+//             printf("pt_%p_%04lu\n", target_pt, GET_UPT_INDEX(vptr, level));
+//         }
+//         break;
+//     }
+//     case cap_vspace_cap: {
+//         asid_t asid = cap_vspace_cap_get_capVSMappedASID(cap);
+//         findVSpaceForASID_ret_t find_ret = findVSpaceForASID(asid);
+//         if (asid) {
+//             printf("%p_pd (asid: %lu)\n",
+//                    find_ret.vspace_root, (long unsigned int)asid);
+//         } else {
+//             printf("%p_pd\n", find_ret.vspace_root);
+//         }
+//         break;
+//     }
+//     case cap_asid_control_cap: {
+//         /* only one in the system */
+//         printf("asid_control\n");
+//         break;
+//     }
+//     case cap_frame_cap: {
+//         vptr_t vptr = cap_frame_cap_get_capFMappedAddress(cap);
+//         findVSpaceForASID_ret_t find_ret = findVSpaceForASID(cap_frame_cap_get_capFMappedASID(cap));
+//         assert(find_ret.status == EXCEPTION_NONE);
+//         _cap_frame_print_attrs_vptr(vptr, find_ret.vspace_root);
+//         break;
+//     }
+//     case cap_asid_pool_cap: {
+//         printf("%p_asid_pool\n", (void *)cap_asid_pool_cap_get_capASIDPool(cap));
+//         break;
+//     }
+// #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
+//     case cap_vcpu_cap: {
+//         printf("%p_vcpu\n", (void *)cap_vcpu_cap_get_capVCPUPtr(cap));
+//         break;
+//     }
+// #endif
+
+//         /* ARM specific caps */
+// #ifdef CONFIG_TK1_SMMU
+//     case cap_io_space_cap: {
+//         printf("%p_io_space\n", (void *)cap_io_space_cap_get_capModuleID(cap));
+//         break;
+//     }
+// #endif
+//     default: {
+//         printf("[unknown cap %lu]\n", (long unsigned int)cap_get_capType(cap));
+//         break;
+//     }
+//     }
 }
 
 void print_object_arch(cap_t cap)
@@ -392,9 +347,7 @@ void print_object_arch(cap_t cap)
     switch (cap_get_capType(cap)) {
     case cap_frame_cap:
     case cap_page_table_cap:
-    case cap_page_directory_cap:
-    case cap_page_upper_directory_cap:
-    case cap_page_global_directory_cap:
+    case cap_vspace_cap:
         /* don't need to deal with these objects since they get handled from vtable */
         break;
 
@@ -425,12 +378,12 @@ void print_object_arch(cap_t cap)
     }
 }
 
-void obj_frame_print_attrs(lookupFrame_ret_t ret)
+void obj_frame_print_attrs(vm_page_size_t frameSize, paddr_t frameBase)
 {
     printf("(");
 
     /* VM size */
-    switch (ret.frameSize) {
+    switch (frameSize) {
     case ARMHugePage:
         printf("1G");
         break;
@@ -442,44 +395,37 @@ void obj_frame_print_attrs(lookupFrame_ret_t ret)
         break;
     }
 
-    printf(", paddr: 0x%p)\n", (void *)ret.frameBase);
+    printf(", paddr: 0x%p)\n", (void *)frameBase);
 }
 
-void arm64_obj_pt_print_slots(pde_t *pdSlot)
+void arm64_obj_pt_print_slots(pte_t *pdSlot)
 {
-    lookupFrame_ret_t ret;
-    pte_t *pt = paddr_to_pptr(pde_pde_small_ptr_get_pt_base_address(pdSlot));
+    pte_t *pt = paddr_to_pptr(pte_pte_table_ptr_get_pt_base_address(pdSlot));
 
-    for (word_t i = 0; i < BIT(PT_INDEX_OFFSET + PT_INDEX_BITS); i += (1 << PT_INDEX_OFFSET)) {
-        pte_t *ptSlot = pt + GET_PT_INDEX(i);
+    for (word_t i = 0; i < BIT(PT_INDEX_BITS); i++) {
+        pte_t *ptSlot = pt + i;
 
-        if (pte_ptr_get_present(ptSlot)) {
-            ret.frameBase = pte_ptr_get_page_base_address(ptSlot);
-            ret.frameSize = ARMSmallPage;
-            printf("frame_%p_%04lu = frame ", ptSlot, GET_PT_INDEX(i));
-            obj_frame_print_attrs(ret);
+        if (pte_4k_page_ptr_get_present(ptSlot)) {
+            printf("frame_%p_%04lu = frame ", ptSlot, i);
+            obj_frame_print_attrs(ARMSmallPage, pte_page_ptr_get_page_base_address(ptSlot));
         }
     }
 }
 
-void arm64_obj_pd_print_slots(pude_t *pudSlot)
+void arm64_obj_pd_print_slots(pte_t *pudSlot)
 {
-    lookupFrame_ret_t ret;
-    pde_t *pd = paddr_to_pptr(pude_pude_pd_ptr_get_pd_base_address(pudSlot));
+    pte_t *pd = paddr_to_pptr(pte_pte_table_ptr_get_pt_base_address(pudSlot));
 
-    for (word_t i = 0; i < BIT(PD_INDEX_OFFSET + PD_INDEX_BITS); i += (1 << PD_INDEX_OFFSET)) {
-        pde_t *pdSlot = pd + GET_PD_INDEX(i);
+    for (word_t i = 0; i < BIT(PT_INDEX_BITS); i++) {
+        pte_t *pdSlot = pd + i;
 
-        if (pde_ptr_get_pde_type(pdSlot) == pde_pde_large) {
-            ret.frameBase = pde_pde_large_ptr_get_page_base_address(pdSlot);
-            ret.frameSize = ARMLargePage;
-
-            printf("frame_%p_%04lu = frame ", pdSlot, GET_PD_INDEX(i));
-            obj_frame_print_attrs(ret);
+        if (pte_ptr_get_pte_type(pdSlot) == pte_pte_page) {
+            printf("frame_%p_%04lu = frame ", pdSlot, i);
+            obj_frame_print_attrs(ARMLargePage, pte_page_ptr_get_page_base_address(pdSlot));
         }
 
-        if (pde_ptr_get_pde_type(pdSlot) == pde_pde_small) {
-            printf("pt_%p_%04lu = pt\n", pdSlot, GET_PD_INDEX(i));
+        if (pte_ptr_get_pte_type(pdSlot) == pte_pte_table) {
+            printf("pt_%p_%04lu = pt\n", pdSlot, i);
             arm64_obj_pt_print_slots(pdSlot);
         }
     }
@@ -487,23 +433,23 @@ void arm64_obj_pd_print_slots(pude_t *pudSlot)
 
 void arm64_obj_pud_print_slots(void *pgdSlot_or_vspace)
 {
-    lookupFrame_ret_t ret;
-    pude_t *pud = paddr_to_pptr(pgde_pgde_pud_ptr_get_pud_base_address(pgdSlot_or_vspace));
+    pte_t *pud = paddr_to_pptr(pte_pte_table_ptr_get_pt_base_address(pgdSlot_or_vspace));
+#ifdef AARCH64_VSPACE_S2_START_L1
+    word_t index_bits = seL4_VSpaceIndexBits;
+#else
+    word_t index_bits = seL4_PageTableIndexBits;
+#endif
+    for (word_t i = 0; i < BIT(index_bits); i++) {
+        pte_t *pudSlot = pud + i;
 
-    for (word_t i = 0; i < BIT(PUD_INDEX_OFFSET + UPUD_INDEX_BITS); i += (1 << PUD_INDEX_OFFSET)) {
-        pude_t *pudSlot = pud + GET_PUD_INDEX(i);
-
-        switch (pude_ptr_get_pude_type(pudSlot)) {
-        case pude_pude_1g:
-            ret.frameBase = pude_pude_1g_ptr_get_page_base_address(pudSlot);
-            ret.frameSize = ARMHugePage;
-
-            printf("frame_%p_%04lu = frame ", pudSlot, GET_PUD_INDEX(i));
-            obj_frame_print_attrs(ret);
+        switch (pte_ptr_get_pte_type(pudSlot)) {
+        case pte_pte_page:
+            printf("frame_%p_%04lu = frame ", pudSlot, i);
+            obj_frame_print_attrs(ARMHugePage, pte_page_ptr_get_page_base_address(pudSlot));
             break;
 
-        case pude_pude_pd: {
-            printf("pd_%p_%04lu = pd\n", pudSlot, GET_PUD_INDEX(i));
+        case pte_pte_table: {
+            printf("pd_%p_%04lu = pd\n", pudSlot, i);
             arm64_obj_pd_print_slots(pudSlot);
 
         }
@@ -515,7 +461,7 @@ void obj_tcb_print_vtable(tcb_t *tcb)
 {
     if (isVTableRoot(TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap) && !seen(TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap)) {
         add_to_seen(TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap);
-        vspace_root_t *vspace = cap_vtable_root_get_basePtr(TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap);
+        vspace_root_t *vspace = VSPACE_PTR(cap_vspace_cap_get_capVSBasePtr(TCB_PTR_CTE_PTR(tcb, tcbVTable)->cap));
 
         /*
          * ARM hyp uses 3 level translation rather than the usual 4 level.
@@ -526,11 +472,11 @@ void obj_tcb_print_vtable(tcb_t *tcb)
         arm64_obj_pud_print_slots(vspace);
 #else
         printf("%p_pd = pgd\n", vspace);
-        for (word_t i = 0; i < BIT(PGD_INDEX_OFFSET + PGD_INDEX_BITS); i += (1UL << PGD_INDEX_OFFSET)) {
-            lookupPGDSlot_ret_t pgdSlot = lookupPGDSlot(vspace, i);
-            if (pgde_pgde_pud_ptr_get_present(pgdSlot.pgdSlot)) {
-                printf("pud_%p_%04lu = pud\n", pgdSlot.pgdSlot, GET_PGD_INDEX(i));
-                arm64_obj_pud_print_slots(pgdSlot.pgdSlot);
+        for (word_t i = 0; i < PT_INDEX_BITS; i++) {
+            pte_t *ptSlot = vspace + i;
+            if (pte_pte_table_ptr_get_present(ptSlot)) {
+                printf("pud_%p_%04lu = pud\n", ptSlot, i);
+                arm64_obj_pud_print_slots(ptSlot);
             }
         }
 #endif
@@ -543,7 +489,9 @@ void debug_capDL(void)
 {
     printf("arch aarch64\n");
     printf("objects {\n");
+#ifdef CONFIG_PRINTING
     print_objects();
+#endif
     printf("}\n");
 
     printf("caps {\n");

--- a/tools/kernel_xmllint.sh
+++ b/tools/kernel_xmllint.sh
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-xml_sources=$(find ../libsel4/arch_include/*/interfaces ../libsel4/sel4_arch_include/*/interfaces -name 'sel4arch.xml')
+xml_sources=$(find ../libsel4/arch_include/*/interfaces ../libsel4/sel4_arch_include/*/interfaces -name 'object-api*.xml')
 if [ -z "$xml_sources" ]; then
-    echo "Unable to find sel4arch.xml files"
+    echo "Unable to find object-api*.xml files"
     exit 1
 fi
 


### PR DESCRIPTION
…n pass the complier with some update

* update

* try to update

* fix word size

* fix captype error

* add the seL4_ARM_SMC

* delete gen py seL4_VCPUReg

* add the seL4_VCPUReg in constant.h

* add some deprecated.h defination

* add some constants.h defination

* change the sel4 size sanity

* fix redefine problem

* fix the lack of seL4_ARM_VSpaceObject

* clean again

* try to fix seL4_CapInitThreadSC defination

* continue

* directly ignore capdl.c part

* change the vspace.c and vspace.h

* ignore the performASIDPoolInvocation

* update objecttype.c

* clean vspace.h

* udpate statedata.h

* try to clean get xxx index and use get kpt index instead

* try again

* fix vspace.c

* try fix again

* update the capdl.c

* update the capdl.c

* update the capdl.c

* update the capdl.c

* update the bootinfo defination

* seems no tooo much diff in libsel4 code